### PR TITLE
added reactive ColorToDepthImage node

### DIFF
--- a/VL.Devices.AzureKinect.vl
+++ b/VL.Devices.AzureKinect.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="FXhAwXcvDLmLrdBs8USiy2" LanguageVersion="2021.4.10.1043" Version="0.128">
-  <NugetDependency Id="CGRGdPSjELiM8Zwqwutmpa" Location="VL.CoreLib" Version="2021.4.10" />
+<Document xmlns:p="property" Id="FXhAwXcvDLmLrdBs8USiy2" LanguageVersion="2021.4.12.1374" Version="0.128">
+  <NugetDependency Id="CGRGdPSjELiM8Zwqwutmpa" Location="VL.CoreLib" Version="2021.4.12" />
   <Patch Id="QLqDcTOr1wsMLsuNhMjakn">
     <Canvas Id="OnK2FssQOETNWfnJIrAYkA" DefaultCategory="Devices.AzureKinect" CanvasType="FullCategory">
       <!--
@@ -5977,6 +5977,153 @@
             </Patch>
           </Patch>
         </Node>
+        <!--
+
+    ************************ ColorToDepthImage (Reactive) ************************
+
+-->
+        <Node Name="ColorToDepthImage (Reactive)" Bounds="919,605" Id="Hcm1TC9Rkq8NGHYKJUkcKU">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" Name="Process" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="URSN1BsPqkCMLudk2OyluN">
+            <Canvas Id="QCxXNpP1PItQElGfBSMlNj" CanvasType="Group">
+              <ControlPoint Id="Bs3uOpM1KTMOcJiK3MmFcU" Bounds="239,217" />
+              <Node Bounds="156,316,249,309" Id="Nxgl9dR3EsePDRF1SgfyXl">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                </p:NodeReference>
+                <Pin Id="NfKpvHAtrnuOEsYoJnkw5x" Name="Force" Kind="InputPin" />
+                <Pin Id="FuMsQlOql42P7zEM67RvVm" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="RKyyNX6pUucMjSBbCs0L5I" Name="Has Changed" Kind="OutputPin" />
+                <ControlPoint Id="SKQ9vBAXimgMqcpHJ9bvhj" Bounds="201,619" Alignment="Bottom">
+                  <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Observable" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="Image" />
+                      </TypeReference>
+                    </p:TypeArguments>
+                  </p:TypeAnnotation>
+                </ControlPoint>
+                <ControlPoint Id="DLh8EwsiCjZLUt9WLNYxln" Bounds="203,322" Alignment="Top" />
+                <Patch Id="PoGrVpQQhv8LAO40iZCAIP" ManuallySortedPins="true">
+                  <Patch Id="EvAY3hpcgzlMJvjZs5yCs8" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="FVjzfUddjEgMMq7zQPBhdR" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="199,423,194,158" Id="N7ruKiOADQ2NcVaMjmqtZS">
+                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="OperationCallFlag" Name="Select" />
+                      <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
+                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    </p:NodeReference>
+                    <Pin Id="DF4ulmicMuvLBvnDyACMkS" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="KlRb0ME50EGMvhvnjyNbLC" Name="Output" Kind="StateOutputPin" />
+                    <Patch Id="PK70RjgFnIBNkB0U7ycPvC" Name="Selector" ManuallySortedPins="true">
+                      <ControlPoint Id="O28KKRw2ro2Nl4AcPVf2sg" Bounds="203,431" />
+                      <ControlPoint Id="GLZtMQAuQQfN9TyBQA0lyC" Bounds="239,574" />
+                      <Node Bounds="239,456,142,26" Id="LwvNWfok8YLMSLraWQQITW">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
+                          <Choice Kind="OperationCallFlag" Name="ColorImageToDepthCamera" />
+                          <PinReference Kind="OutputPin" Name="return" ParameterModifier="return" />
+                          <PinReference Kind="InputPin" Name="Capture" />
+                        </p:NodeReference>
+                        <Pin Id="CsYrODCc2vuLgETC1fM4Xr" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="DMo0XxxKriFPk3Bz2VGue6" Name="Capture" Kind="InputPin" />
+                        <Pin Id="S01aSPwleeaQEARjXfT0GT" Name="Output" Kind="StateOutputPin" />
+                        <Pin Id="PePmEdtWlh0Ln6rF0UKxyw" Name="Result" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="237,513,99,26" Id="EteruSUZK5ZNUZUvYkgP3O">
+                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="AsVLImage" />
+                        </p:NodeReference>
+                        <Pin Id="L8QRdTkcu9POTlLrfgg3s7" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="KzJvO64mqKiL5hUCtaSXM3" Name="Result" Kind="OutputPin" />
+                      </Node>
+                      <ControlPoint Id="MtC81R5U9NbMGbcl33yGgV" Bounds="332,436" />
+                      <Pin Id="SOrKEzwgntnPrUZFJgQpYK" Name="Input 1" Kind="InputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                          <Choice Kind="TypeFlag" Name="Capture" />
+                          <FullNameCategoryReference ID="Devices.AzureKinect" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                      <Pin Id="EYXDFMZdosXLYM8J0nlbJQ" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="O8RnBvcKi7ePQ0SsFYpPOu" Name="Result" Kind="OutputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="Image" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                    </Patch>
+                  </Node>
+                  <Node Bounds="237,343,86,19" Id="TY3IfSiIYCRQS643rygVHk">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="Transformation" />
+                    </p:NodeReference>
+                    <Pin Id="VPlTiV3yvRqLkjAYuxLnoj" Name="Device" Kind="InputPin" />
+                    <Pin Id="C52TkWM6LWfO24Zxujdx6k" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="Fd0dzQMM3PxQWFjkRnW5AF" Bounds="203,387">
+                    <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="Observable" />
+                      <p:TypeArguments>
+                        <TypeReference>
+                          <Choice Kind="TypeFlag" Name="Capture" />
+                          <FullNameCategoryReference ID="Devices.AzureKinect" />
+                        </TypeReference>
+                      </p:TypeArguments>
+                    </p:TypeAnnotation>
+                    <p:ValueBoxSettings>
+                      <p:maxvisiblechars p:Type="Int32">44444</p:maxvisiblechars>
+                      <p:showvalue p:Type="Boolean">false</p:showvalue>
+                    </p:ValueBoxSettings>
+                  </Pad>
+                </Patch>
+              </Node>
+              <Node Bounds="121,262,85,26" Id="SsX7rMu5ZtfODme91Fndp9">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
+                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="JNkEhNP78bUQK1GS1TtN2K" Name="Input" Kind="StateInputPin" />
+                <Pin Id="OZMxaoROE4GMAtUgFYp858" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="I0fSkMFrwUwOwEYIBeefdF" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="QeO9CiFQNGVO7PFJyNSnHR" Bounds="201,642" />
+            </Canvas>
+            <Patch Id="RhpRmPDLEmROhI4jzV02V2" Name="Create" />
+            <Patch Id="CNKq6fh3FiBPHsYZ3QIP4r" Name="Update">
+              <Pin Id="GD0m8sgdDPGO52lmVG2AeF" Name="Sensor" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="EIGVZ5iUgjuOPs6rVgZNms" Name="Output" Kind="OutputPin" Bounds="204,642" />
+            </Patch>
+            <ProcessDefinition Id="LFsNy1wAGYCOn9PiI3Tfhk">
+              <Fragment Id="LBXBqEn3aLBNM9IiSjH0zh" Patch="RhpRmPDLEmROhI4jzV02V2" Enabled="true" />
+              <Fragment Id="VwOiK7QKTAtP93mLavHs1X" Patch="CNKq6fh3FiBPHsYZ3QIP4r" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="PZqOflm6MWYLy6d3RWascj" Ids="GD0m8sgdDPGO52lmVG2AeF,Bs3uOpM1KTMOcJiK3MmFcU" IsHidden="true" />
+            <Link Id="A1V62W9OKIPMuDpuN5IF7Y" Ids="Bs3uOpM1KTMOcJiK3MmFcU,VPlTiV3yvRqLkjAYuxLnoj" />
+            <Link Id="Vpr2A748RHYMJRJiowF3aN" Ids="SOrKEzwgntnPrUZFJgQpYK,O28KKRw2ro2Nl4AcPVf2sg" IsHidden="true" />
+            <Link Id="JkPt2gaoajELRnDvDKY5lg" Ids="GLZtMQAuQQfN9TyBQA0lyC,O8RnBvcKi7ePQ0SsFYpPOu" IsHidden="true" />
+            <Link Id="V6etPXgXFrlPlXRJbSR639" Ids="PePmEdtWlh0Ln6rF0UKxyw,L8QRdTkcu9POTlLrfgg3s7" />
+            <Link Id="Pke8CsjeDQZOVu8XYb2XrC" Ids="C52TkWM6LWfO24Zxujdx6k,CsYrODCc2vuLgETC1fM4Xr" />
+            <Link Id="NL5DS7AftDxN68FQt2G4yM" Ids="O28KKRw2ro2Nl4AcPVf2sg,DMo0XxxKriFPk3Bz2VGue6" />
+            <Link Id="RasivZzsxAXPyvJS4EOAgO" Ids="KzJvO64mqKiL5hUCtaSXM3,GLZtMQAuQQfN9TyBQA0lyC" />
+            <Link Id="OqjdnQIX5R4OK1LIWYreFH" Ids="KlRb0ME50EGMvhvnjyNbLC,SKQ9vBAXimgMqcpHJ9bvhj" />
+            <Link Id="N0ppyFkkuY7POx4gKDxDUu" Ids="EYXDFMZdosXLYM8J0nlbJQ,MtC81R5U9NbMGbcl33yGgV" IsHidden="true" />
+            <Link Id="T29sY2f0rASNtfhPmEqKkT" Ids="Fd0dzQMM3PxQWFjkRnW5AF,DF4ulmicMuvLBvnDyACMkS" />
+            <Link Id="QjcvQivGFVcPvbImJBMzGJ" Ids="Bs3uOpM1KTMOcJiK3MmFcU,JNkEhNP78bUQK1GS1TtN2K" />
+            <Link Id="QbD310UAxc3LgcMq1yaQtF" Ids="I0fSkMFrwUwOwEYIBeefdF,DLh8EwsiCjZLUt9WLNYxln" />
+            <Link Id="ODqr5ypjFudMiQSkWyOVR5" Ids="DLh8EwsiCjZLUt9WLNYxln,Fd0dzQMM3PxQWFjkRnW5AF" />
+            <Link Id="AF4dC6TbiCwPJBGu7G6ABR" Ids="SKQ9vBAXimgMqcpHJ9bvhj,QeO9CiFQNGVO7PFJyNSnHR" />
+            <Link Id="RnRiIdcA5qePguL22yc5N3" Ids="QeO9CiFQNGVO7PFJyNSnHR,EIGVZ5iUgjuOPs6rVgZNms" IsHidden="true" />
+          </Patch>
+        </Node>
       </Canvas>
       <Pad Id="Lk2ioW9RTBuP65dS4UVGch" Bounds="605,810,108,19" ShowValueBox="true" isIOBox="true" Value="Feedback Forum">
         <p:TypeAnnotation>
@@ -6235,11 +6382,6 @@
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <FullNameCategoryReference ID="Control" />
                   </p:NodeReference>
-                  <Pin Id="HkyupcTH6CpNU683PhOj3v" Name="Stick To Last Valid Outputs" Kind="InputPin" />
-                  <Pin Id="BYjKnYQl4svLuMMWDvdPQm" Name="Reset Region On Failure" Kind="InputPin" />
-                  <Pin Id="ROS3ZGI2TRVLq6roLZAui9" Name="Success" Kind="OutputPin" />
-                  <Pin Id="OnpqMj5PRmQLxJa7UN6gw1" Name="Error Message" Kind="OutputPin" />
-                  <Pin Id="O3zYk1A76P0LYve64OKscH" Name="Failure" Kind="OutputPin" />
                   <ControlPoint Id="FbTv5YyHipsOF0ZlzHCRVO" Bounds="99,682" Alignment="Bottom" />
                   <ControlPoint Id="V2GRNO5xVDzOLxInJj4YoG" Bounds="239,682" Alignment="Bottom" />
                   <ControlPoint Id="AUl1fyzosbbMY5cz62T9sh" Bounds="398,682" Alignment="Bottom" />
@@ -6480,6 +6622,12 @@
                       <Pin Id="ODVpWt39gcQO0Cz2mR1303" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
+                  <Pin Id="HkyupcTH6CpNU683PhOj3v" Name="Stick To Last Valid Outputs" Kind="InputPin" />
+                  <Pin Id="BYjKnYQl4svLuMMWDvdPQm" Name="Reset Region On Failure" Kind="InputPin" />
+                  <Pin Id="ROS3ZGI2TRVLq6roLZAui9" Name="Success" Kind="OutputPin" />
+                  <Pin Id="O3zYk1A76P0LYve64OKscH" Name="Failure" Kind="OutputPin" />
+                  <Pin Id="OnpqMj5PRmQLxJa7UN6gw1" Name="Error Message" Kind="OutputPin" />
+                  <Pin Id="IdjQIK3qbQXMAMLy0wpEtC" Name="Exceptions" Kind="OutputPin" />
                 </Node>
               </Patch>
             </Node>
@@ -9162,11 +9310,11 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="MsqCX6Ttc4CLXiQVDI6QhQ" Location="VL.Skia" Version="2021.4.10" />
+  <NugetDependency Id="MsqCX6Ttc4CLXiQVDI6QhQ" Location="VL.Skia" Version="2021.4.12" />
   <PlatformDependency Id="JvKnBkMg9y5QJxBrHlbiSn" Location="VL.Devices.AzureKinect.dll" />
   <NugetDependency Id="KZAfO3faLstMCFyjB36g9Y" Location="System.Numerics.Vectors" Version="4.5.0" />
   <NugetDependency Id="BjHHosGh8QaNOegumIQQIC" Location="VL.Skia3d" Version="1.1.2" />
-  <NugetDependency Id="VJjJ4uUjfMCMWx9Df4PSWA" Location="VL.Stride.Runtime" Version="2021.4.10" />
+  <NugetDependency Id="VJjJ4uUjfMCMWx9Df4PSWA" Location="VL.Stride.Runtime" Version="2021.4.12" />
   <PlatformDependency Id="QFgM5jDAhfxPsQ0SrkSAPc" Location="./dependencies/Microsoft.Azure.Kinect.Sensor/Microsoft.Azure.Kinect.Sensor.dll" />
   <PlatformDependency Id="GML7Urt30mJOajUQRUztY1" Location="./dependencies/Microsoft.Azure.Kinect.Sensor.Record/Microsoft.Azure.Kinect.Sensor.Record.dll" />
 </Document>

--- a/VL.Devices.AzureKinect.vl
+++ b/VL.Devices.AzureKinect.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="FXhAwXcvDLmLrdBs8USiy2" LanguageVersion="2021.4.12.1374" Version="0.128">
-  <NugetDependency Id="CGRGdPSjELiM8Zwqwutmpa" Location="VL.CoreLib" Version="2021.4.12" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="FXhAwXcvDLmLrdBs8USiy2" LanguageVersion="2023.5.0" Version="0.128">
+  <NugetDependency Id="CGRGdPSjELiM8Zwqwutmpa" Location="VL.CoreLib" Version="2023.5.0" />
   <Patch Id="QLqDcTOr1wsMLsuNhMjakn">
     <Canvas Id="OnK2FssQOETNWfnJIrAYkA" DefaultCategory="Devices.AzureKinect" CanvasType="FullCategory">
       <!--
@@ -29,12 +29,12 @@
 
 -->
             <Node Name="OpenDevice (Internal)" Bounds="1040,245,616,551" Id="HXGOA2e8q3SLwtFDxKQ4Yu">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="N4T2w37Qmq3PnZAUpXJr7H">
                 <Node Bounds="1149,268,89,26" Id="PSk9mL9pxWBNIUGOyIYwsw">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
@@ -42,48 +42,48 @@
                   <Pin Id="Lm1nGatsQogNeDbW7TUG3l" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1149,397,89,26" Id="S5y9hxIXXnQPjqv6QqHyuM">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="SetDepthMode" />
                   </p:NodeReference>
                   <Pin Id="CNDQp7196hdPfRz8TfaVYH" Name="Input" Kind="StateInputPin" />
                   <Pin Id="CG8kZMYZTa8NZVdNp1bryu" Name="Value" Kind="InputPin" DefaultValue="NFOV_Unbinned">
-                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="TypeFlag" Name="DepthMode" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="ROskcWT5EW2Pqv77XghBey" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1149,354,102,26" Id="PiqmJIGsSoRNIAnczMgBLU">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetColorResolution" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="LZPDVH6IODTQAkhiVOW522" Name="Input" Kind="StateInputPin" />
                   <Pin Id="EEcoorXrJ3YM3vR3mwNQME" Name="Value" Kind="InputPin" DefaultValue="R1080p">
-                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="TypeFlag" Name="ColorResolution" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="ADX64KdL12uNQ37jOgnYai" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1149,311,89,26" Id="QGhhbyik0KJNwnxdoAZ0S0">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetColorFormat" />
                   </p:NodeReference>
                   <Pin Id="E6h4ef9KN9sMpcNZBy5o9x" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Dvf6djdFwUvPz6x2nkYX7h" Name="Value" Kind="InputPin" DefaultValue="ColorBGRA32">
-                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="TypeFlag" Name="ImageFormat" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="R7O6NwcQ7T8PWXHHjG52Ev" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1149,483,144,26" Id="RzdlEyG934cPPRjHYrCuCV">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetSynchronizedImagesOnly" />
                   </p:NodeReference>
@@ -98,7 +98,7 @@
                 <Link Id="RsyQR4zJWPfLKBmPwyb2Zt" Ids="CmphAGpOHJkPewBbOvKEOP,EEcoorXrJ3YM3vR3mwNQME" />
                 <Link Id="LJ69dRdo9ZQNMNBTCw0Ass" Ids="Cg94EG0BSrcMrnlDAWmt8M,CmphAGpOHJkPewBbOvKEOP" IsHidden="true" />
                 <Node Bounds="1052,306,41,19" Id="QQuPkcMqCPpP4xhIoDHzNH">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Microsoft" />
                     <CategoryReference Kind="AssemblyCategory" Name="Azure" />
@@ -111,7 +111,7 @@
                   <Pin Id="QJx5g8WdwVANSA5EyKA7IQ" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1052,680,77,26" Id="LPktVzVStSVPgwQUj3zBFr">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Device" />
                     <Choice Kind="OperationCallFlag" Name="StartCameras" />
@@ -121,7 +121,7 @@
                   <Pin Id="E5fYKe8zlDQNEwSJ3ppyqx" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1052,722,55,26" Id="K6ER78sPIp2L6VSchsugmB">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="StartImu" />
                   </p:NodeReference>
@@ -137,7 +137,7 @@
                 <Link Id="CbyhxyQm6EXMjqCdHIskvg" Ids="Gdb6v70vp7uOj84quyAPrR,STN3mdecTnlMwur3I7wyNF" IsHidden="true" />
                 <Link Id="UlPRKD9krFXPm19ifwXUKT" Ids="IocK5UpAoePOWa3hyxW834,Gdb6v70vp7uOj84quyAPrR" />
                 <Node Bounds="1149,440,89,26" Id="UswrEN0rbY9NT6sDXJhoLp">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="SetCameraFPS" />
@@ -150,7 +150,7 @@
                 <Link Id="OxX8I562xfyM0LdmwG1k63" Ids="Ohdv21JGOuwLg196wwzmIF,DQd3YTWJuNuNe2ydUDssjG" />
                 <Link Id="FYXoSBTx1BzOeuc05ML7tU" Ids="VvPKye4xiIeNZiGP2TAi1N,Ohdv21JGOuwLg196wwzmIF" IsHidden="true" />
                 <Node Bounds="1149,589,101,26" Id="QJE5VHsxCl5QcPQd1r0zFB">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="SetWiredSyncMode" />
@@ -173,7 +173,7 @@
                 <ControlPoint Id="GVdTbaaqxmGLZh5Acn7ih6" Bounds="1516,415" />
                 <Link Id="AvkYfGtLUKRLm2E5GtU8a0" Ids="OKRzzXtYgBgN7lwCiHWYMS,GVdTbaaqxmGLZh5Acn7ih6" IsHidden="true" />
                 <Node Bounds="1149,528,121,26" Id="PgxcR3bhy7sNlK0yAXhuSH">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="SetDepthDelayOffColor" />
@@ -183,7 +183,7 @@
                   <Pin Id="Ptb5LjlAbjyQOKcXe94FEe" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="1149,634,157,26" Id="HjfRFK7MJu2LF2j369YxSw">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.DeviceConfiguration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="DeviceConfiguration" />
                     <Choice Kind="OperationCallFlag" Name="SetSuboridinateDelayOffMaster" />
@@ -198,8 +198,8 @@
                 <Link Id="Hy19KAFIs8EMSitYf5t7rH" Ids="Ptb5LjlAbjyQOKcXe94FEe,UanZ0Jirqi5LQNUxIcHr9Y" />
                 <ControlPoint Id="EEfN0xr5HgiPVmkoUsjs2U" Bounds="1528,535" />
                 <Link Id="Gri386yigKIOY7xK9raPBO" Ids="RfTzpaMJYDyMAXj2HoHwgY,EEfN0xr5HgiPVmkoUsjs2U" IsHidden="true" />
-                <Node Bounds="1402,601,61,19" Id="HQKxGmlIIokPn2BcU6Qgw4">
-                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                <Node Bounds="1402,601,63,19" Id="HQKxGmlIIokPn2BcU6Qgw4">
+                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="TimeSpan" />
                     <Choice Kind="OperationCallFlag" Name="FromTicks" />
@@ -207,26 +207,9 @@
                   <Pin Id="JI4enliGdwgP6nlO9pd6vV" Name="Value" Kind="InputPin" />
                   <Pin Id="KBrrVnxVTLEPJtD3oQ5p0R" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pin Id="OxCVy57RVtLNKsDP1xON74" Name="Index" Kind="InputPin" Bounds="960,397" />
-                <Pin Id="Cg94EG0BSrcMrnlDAWmt8M" Name="Color Resolution" Kind="InputPin" Bounds="1217,414" />
-                <Pin Id="EtbMBlRmI0LLS1JIrmFpSM" Name="Depth Mode" Kind="InputPin" Bounds="1171,366" />
-                <Pin Id="VvPKye4xiIeNZiGP2TAi1N" Name="FPS" Kind="InputPin" Bounds="989,368" />
-                <Pin Id="GCRBkqT1IaXNcqufr4r72u" Name="Synchronized Images Only" Kind="InputPin" Bounds="1208,462" />
-                <Pin Id="Nt0G4V37ubMQHp4pJ98frT" Name="Sync Mode" Kind="InputPin" Bounds="1102,505" />
-                <Pin Id="OKRzzXtYgBgN7lwCiHWYMS" Name="Depth Delay" Kind="InputPin" Bounds="1312,598">
-                  <p:TypeAnnotation>
-                    <Choice Kind="TypeFlag" Name="Integer32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="RfTzpaMJYDyMAXj2HoHwgY" Name="Delay Off Master" Kind="InputPin" Bounds="1308,599">
-                  <p:TypeAnnotation>
-                    <Choice Kind="TypeFlag" Name="Integer32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="STN3mdecTnlMwur3I7wyNF" Name="Output" Kind="OutputPin" Bounds="1102,695" />
                 <Link Id="Me5HOTK6nRWQPubjKQTm2i" Ids="KBrrVnxVTLEPJtD3oQ5p0R,Uhl3s1MOfTGO46PIvVTHL3" />
                 <Node Bounds="1411,498,63,19" Id="DT8tUbVmMDePI6GQ22Oocs">
-                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="FromTicks" />
                     <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -236,8 +219,8 @@
                 </Node>
                 <Link Id="TJOEqDKuT0XNElCSBtRcrM" Ids="GVdTbaaqxmGLZh5Acn7ih6,MFiOyjkr1WWPfOWdH4bTNf" />
                 <Link Id="FesFxmHWxgDLD6NLyDtszr" Ids="FIf8JEIVXFgMOCxsbzz5YQ,BEYNBKqJmw8LVGLjp1K6sF" />
-                <Node Bounds="1474,451" Id="V67NmEPT5ndOZjZnCcxGVF">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <Node Bounds="1474,451,25,19" Id="V67NmEPT5ndOZjZnCcxGVF">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="*" />
                   </p:NodeReference>
@@ -247,13 +230,13 @@
                 </Node>
                 <Link Id="T72gH4Tz9UqOeYoJxYCiEE" Ids="M474TCy8fIgONikK0dU5HB,UXKLEMzssgPQT4ZNhw51fH" />
                 <Pad Id="UzVXNNSuYx4LQ0gblUoPfS" Comment="" Bounds="1590,425,35,15" ShowValueBox="true" isIOBox="true" Value="10">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Link Id="OMws1ji8uzSN5fTSe33qvt" Ids="UzVXNNSuYx4LQ0gblUoPfS,LH9kWMLzaTqO2dWYoUQsM9" />
                 <Node Bounds="1484,552,25,19" Id="VJq1sbGM4FLOSCxfzGzTN4">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="*" />
                   </p:NodeReference>
@@ -264,12 +247,29 @@
                 <Link Id="Lme0X6E46WKM3WCHR9KIY0" Ids="UzVXNNSuYx4LQ0gblUoPfS,SiBfg7tHBW4LxsbvnDMTQx" />
                 <Link Id="VmhwC6G0pjqLvfY2s4JPVK" Ids="EEfN0xr5HgiPVmkoUsjs2U,SCxRRFkLeX8LNae9Qmhe6G" />
                 <Link Id="RcHNnhbe0XMLBjlGuUBBXD" Ids="B72L03iSxWEPDShRXsx4kO,JI4enliGdwgP6nlO9pd6vV" />
+                <Pin Id="OxCVy57RVtLNKsDP1xON74" Name="Index" Kind="InputPin" Bounds="960,397" />
+                <Pin Id="Cg94EG0BSrcMrnlDAWmt8M" Name="Color Resolution" Kind="InputPin" Bounds="1217,414" />
+                <Pin Id="EtbMBlRmI0LLS1JIrmFpSM" Name="Depth Mode" Kind="InputPin" Bounds="1171,366" />
+                <Pin Id="VvPKye4xiIeNZiGP2TAi1N" Name="FPS" Kind="InputPin" Bounds="989,368" />
+                <Pin Id="GCRBkqT1IaXNcqufr4r72u" Name="Synchronized Images Only" Kind="InputPin" Bounds="1208,462" />
+                <Pin Id="Nt0G4V37ubMQHp4pJ98frT" Name="Sync Mode" Kind="InputPin" Bounds="1102,505" />
+                <Pin Id="OKRzzXtYgBgN7lwCiHWYMS" Name="Depth Delay" Kind="InputPin" Bounds="1312,598">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Integer32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="RfTzpaMJYDyMAXj2HoHwgY" Name="Delay Off Master" Kind="InputPin" Bounds="1308,599">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Integer32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="STN3mdecTnlMwur3I7wyNF" Name="Output" Kind="OutputPin" Bounds="1102,695" />
               </Patch>
             </Node>
             <ControlPoint Id="J53nzkxqmE9OYX31WVHKBa" Bounds="595,156" />
             <ControlPoint Id="BAATmIz3rEkN54hO49qmIf" Bounds="493,154" />
             <Node Bounds="145,202,724,690" Id="A1s9JoQcq8yPNjnoOM7GPF">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -293,7 +293,7 @@
                 <Patch Id="QgTbl5X5s68PUZJi2wqDKY" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="QZrzqCCGog0QIboGonjMo9" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="586,564,116,26" Id="LC5RVku09DaPn7gfv5hjxY">
-                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="CombineLatestImages" />
                   </p:NodeReference>
@@ -301,7 +301,7 @@
                   <Pin Id="G8SgesohTawQS9cozJlBpE" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="587,432,92,95" Id="BjMKVk4ilrbNkQ2dmzTAUh">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                     <Choice Kind="OperationCallFlag" Name="PollResource" />
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -313,11 +313,11 @@
                     <ControlPoint Id="TX7eicuwoJTPwYHMRokghG" Bounds="602,440" />
                     <ControlPoint Id="Nvhoek1jJtLLUNW3OBFvPO" Bounds="602,520" />
                     <Node Bounds="599,465,68,26" Id="NiQ63OzmdLwPwa6N6zbuDM">
-                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="GetCapture" />
                         <PinReference Kind="InputPin" Name="this">
-                          <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="TypeFlag" Name="Device" />
                           </p:DataTypeReference>
                         </PinReference>
@@ -337,7 +337,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="751,430,106,95" Id="EafxLL0PQBjPGG3XVStVvY">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                     <Choice Kind="OperationCallFlag" Name="PollData" />
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -349,7 +349,7 @@
                     <ControlPoint Id="U30wuj3KLs2MirbCYOxtZV" Bounds="766,438" />
                     <ControlPoint Id="SqpGqvcmb8qOXynA6ySytv" Bounds="766,518" />
                     <Node Bounds="763,455,82,26" Id="EWfVZrOgQcHMlkHqhjGcN1">
-                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="AssemblyCategory" Name="Device" />
                         <Choice Kind="OperationCallFlag" Name="GetImuSample" />
@@ -369,7 +369,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="586,646,75,26" Id="NEbnrpLId62MR7CAeDTLo5">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="PubRefCount" />
                   </p:NodeReference>
@@ -377,7 +377,7 @@
                   <Pin Id="OIS9TuufWW2MYDkdpAPiFU" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="586,604,91,26" Id="I2WNbrt4LNCP7fFBJYvuPE">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="BackoffAndRetry" />
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -387,7 +387,7 @@
                   <Pin Id="UB00dZLdyXDQAfgXYokC0A" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="748,644,75,26" Id="UpbULS2aKIjLILo7NVAkWc">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="PubRefCount" />
                   </p:NodeReference>
@@ -395,7 +395,7 @@
                   <Pin Id="TEDHC4aSWHoNtfUhYV7jOJ" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Node Bounds="748,602,91,26" Id="EGh6QXG1KRlOsXd96kQlbk">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="BackoffAndRetry" />
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -404,8 +404,8 @@
                   <Pin Id="KHOSrEZrqt8LNIBixtrLJw" Name="Delay In Seconds" Kind="InputPin" />
                   <Pin Id="JB0txGwby3JLGT3UTgFqh3" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="399,263,109,75" Id="Jtx9OeuWjukM4Srlh6f9qK">
-                  <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                <Node Bounds="399,263,169,75" Id="Jtx9OeuWjukM4Srlh6f9qK">
+                  <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                     <CategoryReference Kind="Category" Name="Resources" />
                     <Choice Kind="OperationCallFlag" Name="New" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -414,8 +414,8 @@
                   <Patch Id="CZOFrBj16bnM6xzlmlbG2k" Name="Factory" ManuallySortedPins="true">
                     <Pin Id="RBgDMq74FpXNqF0wrLvWaq" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="PvwZ947GbS8OzDKJk8uMcv" Bounds="413,331" />
-                    <Node Bounds="411,286,85,19" Id="Hm4NQFCR1ACLsjnesLfPpS">
-                      <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <Node Bounds="411,286,145,19" Id="Hm4NQFCR1ACLsjnesLfPpS">
+                      <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="OpenDevice" />
                       </p:NodeReference>
@@ -432,7 +432,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="399,354,83,26" Id="FmnOHfCtbNdNB8mRjp0Yj5">
-                  <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ShareInParallel" />
                     <PinReference Kind="InputPin" Name="Delay Disposal In Milliseconds" />
@@ -442,7 +442,7 @@
                   <Pin Id="FczYECtuPDqN6dUH3wwWkh" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="394,437,106,146" Id="JdIPuZb3aQrPu8rHvRSR0o">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationCallFlag" Name="Using (Provider)" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   </p:NodeReference>
@@ -454,7 +454,7 @@
                     <ControlPoint Id="J3S4P2H9ytXOU2ZmB116Ac" Bounds="407,448" />
                     <ControlPoint Id="BItXtjHI31KM2Tdwp6Bq4v" Bounds="407,576" />
                     <Node Bounds="406,460,82,26" Id="IKsN9jIJTBgLqP4bZdNh1H">
-                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="AssemblyCategory" Name="Device" />
                         <Choice Kind="OperationCallFlag" Name="GetCalibration" />
@@ -464,7 +464,7 @@
                       <Pin Id="IjKHU0vefwrMrxcQSpUw63" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="408,538,46,19" Id="GGLfx3S38Q2M9Z0d2u01R3">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                         <Choice Kind="OperationCallFlag" Name="Return" />
@@ -473,7 +473,7 @@
                       <Pin Id="NuFkCLLJ5kfLYctvUN3EWV" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="408,503,46,26" Id="GKWGY5e3CFHNKxVeQcIuCK">
-                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Nullable" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -484,7 +484,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="394,731,91,26" Id="Nvhy9RbAD3bPly3NEnh0RI">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="BackoffAndRetry" />
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -494,7 +494,7 @@
                   <Pin Id="GXD8Zf6RiNpMZbJ4NGkYP9" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Pad Id="OPYxdrJxyRAOYnaMQfN7Ib" Bounds="339,788,201,75" ShowValueBox="true" isIOBox="true" Value="Don't use PubRef here - we want a cold observable, each subscriber shall get the value pushed">
-                  <p:TypeAnnotation>
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                   <p:ValueBoxSettings>
@@ -503,7 +503,7 @@
                   </p:ValueBoxSettings>
                 </Pad>
                 <Node Bounds="233,465,100,123" Id="DIbUtUhtgJqL1IrYLb2UR6">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationCallFlag" Name="Using (Provider)" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   </p:NodeReference>
@@ -515,7 +515,7 @@
                     <ControlPoint Id="AP08W3xVrnpLUmVvnxNXqM" Bounds="248,473" />
                     <ControlPoint Id="SmO7ePPXP8vN1BtoXspXVu" Bounds="248,581" />
                     <Node Bounds="245,508,76,19" Id="ErxaOdJLYDaN5QmdsdllOr">
-                      <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                      <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="FirmwareInfo" />
                       </p:NodeReference>
@@ -523,7 +523,7 @@
                       <Pin Id="OblcvcChBtBM6MfrKwotI0" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="245,542,46,19" Id="FYv7jEq3VRqOZ12oVlQPXT">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                         <Choice Kind="OperationCallFlag" Name="Return" />
@@ -534,7 +534,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="239,725,91,26" Id="KMFLfeAo9IkMu82SLfaPYq">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="BackoffAndRetry" />
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -547,7 +547,7 @@
             </Node>
             <ControlPoint Id="HlL0jrFimQ3OcU87dRKqSM" Bounds="679,154" />
             <Pad Id="DZuVxSQpPHjNgBHTWg4mj0" Bounds="-80,374,209,125" ShowValueBox="true" isIOBox="true" Value="The Update method must not crash. It must always be possible to setup the new resource provider as well as the output observables so downstream sinks get a chance to unsubribe!">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -558,7 +558,7 @@
             <ControlPoint Id="Sqk6D21Oh1TMmUdxrhErOx" Bounds="789,169" />
             <ControlPoint Id="E60Ou4sMa1vMqGw7XcqEHe" Bounds="395,973" />
             <Node Bounds="393,932,45,19" Id="HdWMG34OJWlOT4Zoh4uyp2">
-              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Switch" />
                 <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -569,7 +569,7 @@
               <Pin Id="CBUA7j3UK5kOL2nyYyckMZ" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="590,932,45,19" Id="PY8UNaEHnv7LJyeda49ALX">
-              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Switch" />
                 <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -580,7 +580,7 @@
               <Pin Id="LMGzHSpRyCDO3sJAzCw7vs" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="752,932,45,19" Id="PRjVb2HeXgvL1YAjV5TTaB">
-              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Switch" />
                 <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -601,12 +601,12 @@
 
 -->
             <Node Name="FirmwareInfo (Internal)" Bounds="1063,938,502,564" Id="NgUiSZlvChFLdjVpiNrIIr">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="JRXUHdAys1xOADzigXSC3Y">
                 <Node Bounds="1075,994,51,26" Id="QJZMiPkBvoCOVA2g5Gf8Ob">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Device" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Version" />
                   </p:NodeReference>
@@ -615,7 +615,7 @@
                   <Pin Id="NimkbY9z9mrNKwxSiUyVUB" Name="Version" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1121,1034,77,26" Id="VBSql9WfLEhQEdtPAFe61i">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="HardwareVersion" />
                     <Choice Kind="OperationCallFlag" Name="Depth" />
@@ -625,7 +625,7 @@
                   <Pin Id="JdS2kuxzMBmQJ5SNhsdwfv" Name="Depth" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1215,1079,55,19" Id="Kn9PewSubl2P1I2BEokIR4">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
                   </p:NodeReference>
@@ -633,7 +633,7 @@
                   <Pin Id="JaRL90JFpQULfL70FsoL9c" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1121,1094,77,26" Id="CWfb6nj0WRfM2WxIEjIPVZ">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="HardwareVersion" />
                     <Choice Kind="OperationCallFlag" Name="RGB" />
@@ -643,7 +643,7 @@
                   <Pin Id="GcXNhmhLQeMQYrYgn0xp10" Name="RGB" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1215,1143,55,19" Id="Rv61KHt3TTvNb0ABd0LsFg">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
                   </p:NodeReference>
@@ -651,7 +651,7 @@
                   <Pin Id="NpmXlbpwgWFQE9q23pnla8" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1114,1160,77,26" Id="Bu43hwjqFGiQPpWIOcNP3O">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="DepthSensor" />
                   </p:NodeReference>
@@ -660,7 +660,7 @@
                   <Pin Id="MUWRLGhXJqkN9PKt8K7wcS" Name="Depth Sensor" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1223,1233,55,19" Id="CecfdeB44x0Lz5PT77gYi0">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
                   </p:NodeReference>
@@ -678,7 +678,7 @@
                 <Pin Id="K7a8LlhE7qnPdjg58vWG4k" Name="Input" Kind="InputPin" Bounds="1083,1170" />
                 <Link Id="Jy4D37dqeisOAyzmOZIwZ4" Ids="K7a8LlhE7qnPdjg58vWG4k,LJm3vQdFmwoOkMH1oHJvUY" IsHidden="true" />
                 <Node Bounds="1277,1431,205,19" Id="Qn829cISNzOOcMhlREPNDp">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
                   </p:NodeReference>
@@ -696,7 +696,7 @@
                   <Pin Id="UHRYNmC4LJUO3O1jTFy6BY" Name="Input 11" Kind="InputPin" />
                 </Node>
                 <Pad Id="RSrvJApcxAVN4kOn1I8dTW" Comment="" Bounds="1275,1325,88,15" ShowValueBox="true" isIOBox="true" Value="RGB camera: ">
-                  <p:TypeAnnotation>
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="String" />
                     <FullNameCategoryReference ID="Primitive" />
                   </p:TypeAnnotation>
@@ -704,7 +704,7 @@
                 <Link Id="O90eVJxXSGZOfuC7rUFW6s" Ids="RSrvJApcxAVN4kOn1I8dTW,S5wnJuJe2gOLhivMHJ62SB" />
                 <Link Id="Cv7KLd5BXmQLuGZioOUaK0" Ids="NpmXlbpwgWFQE9q23pnla8,ExHlLtFLpxsLoNhcBF7y4R" />
                 <Node Bounds="1514,1400,39,19" Id="PO2bXltWTmCNz0jLvhUCD9">
-                  <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="CRLF" />
                   </p:NodeReference>
@@ -712,7 +712,7 @@
                 </Node>
                 <Link Id="Jg7ELqzoE5AOp5xHo1Zpph" Ids="NbRgVmVuVCTONovmeHvmYX,Qkeayb6ORXoP0ORs4umkw9" />
                 <Pad Id="GkvAyde9vXnLYIr8ztssg1" Comment="" Bounds="1336,1348,88,15" ShowValueBox="true" isIOBox="true" Value="Depth camera: ">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -720,7 +720,7 @@
                 <Link Id="FZfCRjNI8o0PX4wWnJwvUM" Ids="JaRL90JFpQULfL70FsoL9c,LVQBT5eP35ZNszKlEkhldx" />
                 <Link Id="Lj0UJKpLoFyN2hffOIXplQ" Ids="NbRgVmVuVCTONovmeHvmYX,DttdTl7jev6PfNyAb1vfl0" />
                 <Pad Id="KFKTHQw2OCFLi7U3lRUts3" Comment="" Bounds="1403,1370,86,15" ShowValueBox="true" isIOBox="true" Value="Depth Sensor: ">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -728,14 +728,14 @@
                 <Link Id="ENd3q8NH865PdtjXgFGFjS" Ids="MK2SDOHpNguMjzCXgHz60s,AhPcP9Bn8N8M3laYCMxHCX" />
                 <Link Id="VMLT4zqaQhcMrPg9KDsJNH" Ids="NbRgVmVuVCTONovmeHvmYX,FjEJIL2KSwtQMFy7kwutcj" />
                 <Pad Id="M0jc1XmTS9QOm9dMaYzi09" Comment="" Bounds="1462,1393,47,15" ShowValueBox="true" isIOBox="true" Value="Audio: ">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Link Id="GRSudnbn4CMP96RGMhB1Q1" Ids="M0jc1XmTS9QOm9dMaYzi09,I1yO9vPM3GBPAtG9gAF6Ja" />
                 <Link Id="FTL0itXgaOxOWunKJFyP4k" Ids="Esk4mrOx0EKMfYYuBKrpYW,BhaKCAkbWdBQPvBrps78vJ" />
                 <Node Bounds="1115,1248,77,26" Id="RuNgUWyGzJYPmdvsM4t8ef">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.HardwareVersion" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Audio" />
                     <CategoryReference Kind="AssemblyCategory" Name="HardwareVersion" NeedsToBeDirectParent="true" />
@@ -746,7 +746,7 @@
                 </Node>
                 <Link Id="GfdxyUEX2q0MFJCcUi1Yvt" Ids="EPwNKHRUJroP4aT9c3QAZ9,ESZDE0UoA23MPjvs6V7orH" />
                 <Node Bounds="1204,1304,55,19" Id="UtDIgeAzGW7PqZSrSOIZgr">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
                   </p:NodeReference>
@@ -761,8 +761,8 @@
               </Patch>
             </Node>
             <ControlPoint Id="D6ZvBcJMzpWNTwazMSFSYj" Bounds="240,978" />
-            <Node Bounds="241,926" Id="BrOv6WluzBiMGLlXabgb4e">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <Node Bounds="241,926,65,19" Id="BrOv6WluzBiMGLlXabgb4e">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -864,17 +864,17 @@
           <Patch Id="QHc7KLcDuFRP1txEzv4pfP" Name="Update (Internal)">
             <Pin Id="FA66N3BQ5SaLBDLmDKrR1r" Name="Device Index" Kind="InputPin" />
             <Pin Id="Pv1pB4IgbO6NqGmuPJx6qp" Name="Color Resolution" Kind="InputPin" DefaultValue="R720p">
-              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                 <Choice Kind="TypeFlag" Name="ColorResolution" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="FZYLI5Rj0VNNbyB86z7Nku" Name="Depth Mode" Kind="InputPin" DefaultValue="NFOV_Unbinned">
-              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                 <Choice Kind="TypeFlag" Name="DepthMode" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="PyuOCkA0kFjLqmFLu5Cltg" Name="FPS" Kind="InputPin" Bounds="506,182" DefaultValue="FPS30">
-              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                 <Choice Kind="TypeFlag" Name="FPS" />
               </p:TypeAnnotation>
             </Pin>
@@ -883,7 +883,7 @@
             <Pin Id="Fam9rzV3SGWNahM1xCldwW" Name="Sync Mode" Kind="InputPin" Bounds="633,142" Visibility="Optional" />
             <Pin Id="KIc4YDc4wgnPTL8toEuQAE" Name="Delay Off Master" Kind="InputPin" Bounds="827,185" Visibility="Optional" Summary="Specify in μs" />
             <Pin Id="LLIOHJ7Z6soPCKZ8gSt1JK" Name="Enabled" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -892,7 +892,7 @@
           <Patch Id="JAxzRwzHBfGPwFAhPJtYwW" Name="Dispose (Internal)" />
           <Patch Id="Q7t62X6hm3pQNLvj8cUZ0g" Name="GetCaptures (Internal)">
             <Pin Id="J3ug6gKG4vaPoySXVeSt8i" Name="Captures" Kind="OutputPin">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -911,15 +911,15 @@
 
 -->
       <Node Name="ColorImage" Bounds="120,416" Id="DkzhsXR7zfbLihL0Yfm4ke">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="Ke26h7oVCGVOjtGHKqDmvA">
           <Canvas Id="Iplr0vkESA8LjhdlF0He6v" CanvasType="Group">
             <ControlPoint Id="UlKdSjpCb4pOMXGiRx6W8q" Bounds="378,215" />
             <ControlPoint Id="JaxunpsGMH3L14pHQSCaEl" Bounds="378,371" />
-            <Node Bounds="377,309,88,19" Id="QNKKhT02dm3LKy6h988vAo">
-              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+            <Node Bounds="376,309,88,19" Id="QNKKhT02dm3LKy6h988vAo">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
               </p:NodeReference>
@@ -931,7 +931,7 @@
               <Pin Id="B8uZQaqSueBNEo6w3OJkNQ" Name="Drop Count" Kind="OutputPin" />
             </Node>
             <Node Bounds="376,247,69,19" Id="GjBrPlFGB74MpUNgGhNLCc">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ColorImage (Reactive)" />
               </p:NodeReference>
@@ -961,7 +961,7 @@
 
 -->
       <Node Name="DepthImage" Bounds="120,516" Id="GQu8owoGOXsQXq8kbwp3zZ">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="TastemxP4W6MblIt4InfF9">
@@ -969,7 +969,7 @@
             <ControlPoint Id="F9H127OZOmoMwQSbY6XMQH" Bounds="447,226" />
             <ControlPoint Id="QyVLwwtn9FJN1TssxPLDjH" Bounds="447,393" />
             <Node Bounds="445,332,88,19" Id="DCGX7iXJ7RTNudmRUkN6Vf">
-              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
               </p:NodeReference>
@@ -981,7 +981,7 @@
               <Pin Id="JYsKLTt8hzaPZhtLxLn6CK" Name="Drop Count" Kind="OutputPin" />
             </Node>
             <Node Bounds="445,272,71,19" Id="Jdi8zTBEJUBPQgVRIU9pCm">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="DepthImage (Reactive)" />
               </p:NodeReference>
@@ -1020,7 +1020,7 @@
             <ControlPoint Id="BUEKgfnUr0XLXKkyQEAU3C" Bounds="148,130" />
             <ControlPoint Id="Slk2S70yjk6NUwOTfwHn1u" Bounds="181,1013" />
             <Node Bounds="179,967,65,19" Id="MKYJgp2TirpLQ5zLqJW8wy">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -1035,12 +1035,12 @@
 
 -->
             <Node Name="GetPoints (Internal)" Bounds="629,915,373,970" Id="HKZElkEXtNtPfw92mDHWMu">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="Rkw8UNxh85mNIbQ7oK8QAz">
                 <Node Bounds="676,1171,208,635" Id="FHxbLpyB32dPRgIukNcdaC">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                     <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
@@ -1057,7 +1057,7 @@
                     <Patch Id="B0TE6QxrtqsM8BTw4aQ6am" Name="Dispose" ManuallySortedPins="true" />
                     <ControlPoint Id="PiLiEQlOh9fLcTJYJ0p6BT" Bounds="789,1189,-46,0" />
                     <Node Bounds="787,1289,45,19" Id="JFueU8fWVdnPI7BXrTJwW1">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="*" />
                       </p:NodeReference>
@@ -1067,7 +1067,7 @@
                       <Pin Id="CNjp3Fk8MATMHJfJIQ8JiL" Name="Input 3" Kind="InputPin" />
                     </Node>
                     <Node Bounds="761,1405,44,26" Id="DhfUdaeWDpYQGQfarSpnuO">
-                      <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Z" />
                         <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -1076,7 +1076,7 @@
                       <Pin Id="P33McEDutFaNJP6pJo7Nrr" Name="Z" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="763,1457,25,19" Id="LYwWTllGOPvMzq37kRsmId">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="&gt;" />
                       </p:NodeReference>
@@ -1085,7 +1085,7 @@
                       <Pin Id="BJ76ey7dp4QPjNmiLizZOP" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="763,1490,37,19" Id="DLc8aHnKZZaPlO6VOWwnzy">
-                      <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="AND" />
                       </p:NodeReference>
@@ -1094,7 +1094,7 @@
                       <Pin Id="G8j6waNVqbqPC7IwsaZybV" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="814,1458,25,19" Id="D0DaGz5ACSwL8wyciW1mob">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="&lt;" />
                       </p:NodeReference>
@@ -1102,8 +1102,8 @@
                       <Pin Id="Sgoj3mSNmvdOQJJBePkXpg" Name="Input 2" Kind="InputPin" />
                       <Pin Id="VIW5XI2DbNzOQlqqIbVtY4" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="740,1359,52,26" Id="NbXkxk9zigNNqjwW03Mzom">
-                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                    <Node Bounds="740,1359,52,19" Id="NbXkxk9zigNNqjwW03Mzom">
+                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="GetSlice" />
                         <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1113,18 +1113,20 @@
                       <Pin Id="GK66Yyod9YoPeFc4JbaF67" Name="Index" Kind="InputPin" />
                       <Pin Id="OBFfmZfMiiTM1Rs8qg2i8e" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="699,1525,173,245" Id="PNgdo0BEKdrQRgtedonajo">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <Node Bounds="699,1525,173,246" Id="PNgdo0BEKdrQRgtedonajo">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="ApplicationStatefulRegion" Name="If" />
                         <FullNameCategoryReference ID="Primitive" />
                       </p:NodeReference>
                       <Pin Id="Uft6CUYebRxPgogv4FMKbo" Name="Condition" Kind="InputPin" />
+                      <ControlPoint Id="KDPTLcoJnTUM61Zgg8YNMf" Bounds="713,1765" Alignment="Bottom" />
+                      <ControlPoint Id="BDDhIbEUtgYL6yGuLl9PBO" Bounds="725,1531" Alignment="Top" />
                       <Patch Id="LePhj1O4HWUNHgAW2sFts7" ManuallySortedPins="true">
                         <Patch Id="Ul2PIAFvsZ4OKu3RS6EAVc" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="SX305xHBP74PZy47BEK6IJ" Name="Then" ManuallySortedPins="true" />
                         <Node Bounds="711,1711,67,26" Id="FYBRdSlqxxfOoTkJjsAvVD">
-                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Add" />
                             <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -1134,7 +1136,7 @@
                           <Pin Id="QRa0NNGhmbvLxajuJ9h5ik" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="741,1549,44,26" Id="FKPgBNc7gNhN4h10hzHwdo">
-                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="X" />
                             <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -1143,7 +1145,7 @@
                           <Pin Id="G16ArzRiBDvOZxpDqXNbCi" Name="X" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="772,1679,46,19" Id="UgeIF5RbHsmNK9vWHOjIPZ">
-                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                             <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -1154,7 +1156,7 @@
                           <Pin Id="UdPhLKM1lTEMLUkwHns6kT" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="741,1590,44,26" Id="LgQxsAlIjyXM9ouTYJlKch">
-                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Y" />
                             <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -1163,29 +1165,27 @@
                           <Pin Id="BYhuHRTVwvDMrfX7S6utc6" Name="Y" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="787,1635,25,19" Id="NZONT6fbondNqJMcFrmqDh">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="*" />
                           </p:NodeReference>
                           <Pin Id="RefSVPR1tkRO5yr2Z1d3du" Name="Input" Kind="InputPin" />
                           <Pin Id="QZGbPDPjl1eNq0SAPN92TC" Name="Input 2" Kind="InputPin" DefaultValue="-1">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Float32" />
                             </p:TypeAnnotation>
                           </Pin>
                           <Pin Id="R4IRY8YSFqQOPAvRYeEkST" Name="Output" Kind="OutputPin" />
                         </Node>
                         <Pad Id="QikMT9dQWSrPjzWQ1mtV2j" Comment="" Bounds="806,1603,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pad>
                       </Patch>
-                      <ControlPoint Id="KDPTLcoJnTUM61Zgg8YNMf" Bounds="713,1765" Alignment="Bottom" />
-                      <ControlPoint Id="BDDhIbEUtgYL6yGuLl9PBO" Bounds="725,1532" Alignment="Top" />
                     </Node>
                     <Node Bounds="787,1241,55,19" Id="DX0mTJlwJkAOgPJpxM99r1">
-                      <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="DIVMOD" />
                         <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -1196,7 +1196,7 @@
                       <Pin Id="RRTu32zOY6YPSEsAKSFvbZ" Name="Remainder" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="787,1319,25,19" Id="Fdw76zpcB5sMXcvMqfejpC">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="+" />
                       </p:NodeReference>
@@ -1205,7 +1205,7 @@
                       <Pin Id="OHUnaSQOUnzMb80LeI3Kgi" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="787,1208,25,19" Id="QC5HrC9J2cmOIFzl2krdV2">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="*" />
                       </p:NodeReference>
@@ -1216,7 +1216,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="831,1002,35,19" Id="SRC3EeCQHgMOuVak9xH8nF">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Max" />
                   </p:NodeReference>
@@ -1225,7 +1225,7 @@
                   <Pin Id="MaGY0MEvTsMOUXQCVeZYEL" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Pad Id="QxNMisRh4R6Or3S2Z835GC" Comment="Input" Bounds="833,967,20,15" ShowValueBox="true" isIOBox="true" Value="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -1233,8 +1233,8 @@
                 <ControlPoint Id="KKzBjBDsJqBNRMOkQ1wjCN" Bounds="920,940" />
                 <Link Id="U6dyBtjqRvlO1N5mmBP66i" Ids="KKzBjBDsJqBNRMOkQ1wjCN,KV8asvfWxZWNMeIRvmUk8x" />
                 <Link Id="PSMHbtGNXV2NevG6nmeKan" Ids="JNzBC4aRvvTQKkvjHgLuzO,KKzBjBDsJqBNRMOkQ1wjCN" IsHidden="true" />
-                <Node Bounds="918,964,51,26" Id="C0LFUMegHV0Osyv6aCxpz6">
-                  <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <Node Bounds="918,964,51,19" Id="C0LFUMegHV0Osyv6aCxpz6">
+                  <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Inc" />
                     <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -1246,7 +1246,7 @@
                 <ControlPoint Id="O7usyOlWCgjQPSrbwJVq0q" Bounds="743,933" />
                 <Link Id="RjVDw6HuA1rN6afVOPd8aH" Ids="UOmYonBZVvoOjsQmLF2u3v,O7usyOlWCgjQPSrbwJVq0q" IsHidden="true" />
                 <Node Bounds="684,1097,32,19" Id="UCZGJwpQxmHO0i1evridJL">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="DIV" />
                   </p:NodeReference>
@@ -1257,7 +1257,7 @@
                 <Link Id="ISeY60SsZt4Nz9UBylPR0X" Ids="PKBBELbyYsDOQ1l2MB6eJ4,TggkqDfGNqMPjdOSG5qBSE" />
                 <Link Id="MQgDYqhiqN3PuHFoQr6ikg" Ids="FHxNFwUHk5hNjC0exddFIw,PiLiEQlOh9fLcTJYJ0p6BT" IsHidden="true" />
                 <Node Bounds="707,1132,66,26" Id="RQIDhVokqI2LLw5Dj3q0wl">
-                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -1268,7 +1268,7 @@
                 <Link Id="VFi3ofsZ1s7QEHrxtJCTk2" Ids="UTb8aTnRR5xM6Iv2GQkCQS,KSglEcZFAw8QSrG7bzzUmv" IsFeedback="true" />
                 <Link Id="EcrT9LNsCvPOlM6V1K2HkA" Ids="KlxSo0br2KuOORNc0jehzu,UTb8aTnRR5xM6Iv2GQkCQS" />
                 <Node Bounds="711,1822,66,26" Id="S85HxLwTQVsN3EpO06qW7e">
-                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToSpread" />
                     <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -1289,7 +1289,7 @@
                 <Link Id="EYfHpi1YWs1PGJTefppSc1" Ids="G8j6waNVqbqPC7IwsaZybV,Uft6CUYebRxPgogv4FMKbo" />
                 <Link Id="GnBg0KBdMVWNxaUNOs7PCM" Ids="O7usyOlWCgjQPSrbwJVq0q,BvuZbbfZ2q3P4DAED2c7ax" />
                 <Node Bounds="685,971,44,26" Id="MKgva4KPqSUNYvr0ImVawK">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Count" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1299,7 +1299,7 @@
                 </Node>
                 <Link Id="RE0M3OXcqtwO6wp8EmT4dA" Ids="O7usyOlWCgjQPSrbwJVq0q,RzcLUIQv8BYN9o14twC9Rt" />
                 <Node Bounds="711,1063,25,19" Id="SJhOtKcEcuSQSm2Qoc1pzO">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="*" />
                   </p:NodeReference>
@@ -1346,13 +1346,13 @@
                 <Pin Id="UOmYonBZVvoOjsQmLF2u3v" Name="Input" Kind="InputPin" Bounds="658,654" />
                 <Pin Id="FcI05mQtqSuOtel0cTojZR" Name="Width" Kind="InputPin" />
                 <Pin Id="JNzBC4aRvvTQKkvjHgLuzO" Name="Decimation" Kind="InputPin" Bounds="609,626" DefaultValue="4">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="Tng54yqB4fJNsUfUJk0KeK" Name="Min Z" Kind="InputPin" Bounds="776,1071" />
                 <Pin Id="TNP7uEwP7JqMW3ItXTg9HU" Name="Max Z" Kind="InputPin" Bounds="775,1121" DefaultValue="8">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -1362,8 +1362,8 @@
             <ControlPoint Id="NeC2X5kciDIOXWhAgWIieu" Bounds="341,152" />
             <ControlPoint Id="VOSZxMhcSvuMYbUq3KhdoH" Bounds="420,152" />
             <ControlPoint Id="Bii8BLYcQvlOufTwgtDzV5" Bounds="510,152" />
-            <Node Bounds="135,211,420,738" Id="VPDsUDKa5YfLfBl7RgXpop">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+            <Node Bounds="135,211,427,738" Id="VPDsUDKa5YfLfBl7RgXpop">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -1380,7 +1380,7 @@
                 <Patch Id="V1T7YTdxD06LbWLPhCayOy" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="SO5VWxV2F8qO8gZAFJA5AY" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="179,350,371,566" Id="IsTKku9VXKdMyP2rdnojV6">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                     <Choice Kind="OperationCallFlag" Name="Select (Many)" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -1395,7 +1395,7 @@
                     <ControlPoint Id="LUkJxB48nrIOzdGJJEEqMV" Bounds="472,358" />
                     <ControlPoint Id="I71wnt2d0UKO4qKekBbLHn" Bounds="255,909" />
                     <Node Bounds="433,496,46,26" Id="HPf3vSFNob2OYX4d0Kg68n">
-                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Nullable" />
                         <Choice Kind="OperationCallFlag" Name="Value" />
@@ -1405,7 +1405,7 @@
                       <Pin Id="VdNNo7p6tfwN2W2kJIa5ec" Name="Value" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="256,602,282,275" Id="ARgCGw3fSIWL9vP4DAmhYQ">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                         <Choice Kind="OperationCallFlag" Name="Select" />
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -1420,7 +1420,7 @@
                         <ControlPoint Id="H1nN2ggkSZOL9WAts8xuVq" Bounds="332,610" />
                         <ControlPoint Id="Gayz3LYZkNALtiJ3wRcwqk" Bounds="293,870" />
                         <Node Bounds="268,637,45,26" Id="QLppJLtc3x2LoZYjUPFTNg">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Capture" />
                             <Choice Kind="OperationCallFlag" Name="Depth" />
@@ -1430,7 +1430,7 @@
                           <Pin Id="DvfeXYzou1KO8sp5Ot2ZOz" Name="Depth" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="394,723,132,26" Id="MEv32uJL5gwNsfDrikaGcX">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
                             <Choice Kind="OperationCallFlag" Name="DepthImageToPointCloud" />
@@ -1443,20 +1443,20 @@
                           <Pin Id="PuufM86uZDBNL4T5gEMwiR" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="290,768,102,26" Id="C6dmtPjuJtgLgulznk1rTV">
-                          <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                          <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetPointCloudData" />
                           </p:NodeReference>
                           <Pin Id="NtT5IUI1pDPPwAhCkFk8Yx" Name="Input" Kind="StateInputPin" />
                           <Pin Id="Q0VWBw9UVrWNIMSGmJNooq" Name="Scaling" Kind="InputPin" DefaultValue="0.001">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Float32" />
                             </p:TypeAnnotation>
                           </Pin>
                           <Pin Id="FrMYWx0NbjnNRW6cGt9J4d" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="291,818,85,19" Id="LpIxofg8fhSLLZxokYUzpT">
-                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PointCloud" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PointCloud" LastDependency="VL.Devices.AzureKinect.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetPoints" />
                             <CategoryReference Kind="Category" Name="PointCloud" NeedsToBeDirectParent="true" />
@@ -1469,7 +1469,7 @@
                           <Pin Id="EACprv1GqyLQbFbEaZXdxl" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="309,675,69,26" Id="RC4TGQZW6OVN16WeU3UubU">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Image" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Image" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Image" />
                             <Choice Kind="OperationCallFlag" Name="WidthPixels" />
@@ -1481,7 +1481,7 @@
                       </Patch>
                     </Node>
                     <Node Bounds="191,382,72,26" Id="V4fMcf4mhiZPRavQixdHq4">
-                      <p:NodeReference>
+                      <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="GetCaptures" />
                         <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -1491,7 +1491,7 @@
                       <Pin Id="EQlsTwXK0GcOmFWmKEP97E" Name="Captures" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="428,546,71,26" Id="L7C8RHbMdEuNzt7nHqKCzd">
-                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                      <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -1500,7 +1500,7 @@
                       <Pin Id="RmJqLTIKMSlM14g3rLTLA8" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="254,432,90,129" Id="M2NOca31pVDNRxPiEidnUM">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="OperationCallFlag" Name="Where" />
                         <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -1513,7 +1513,7 @@
                         <ControlPoint Id="RqrkD64ukhoN8dgwocxnjm" Bounds="258,440" />
                         <ControlPoint Id="TZtPtQrIFITOX3cjtlDD6P" Bounds="269,554" />
                         <Node Bounds="266,456,45,26" Id="NsbCoVVrXCSPcGF1JuMSux">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Capture" />
                             <Choice Kind="OperationCallFlag" Name="Depth" />
@@ -1523,7 +1523,7 @@
                           <Pin Id="JbrKrXxXqeeLNSqBukfXdH" Name="Depth" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="267,503,65,19" Id="AzKxx5qPJy4MCWc2R7fd6e">
-                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                           </p:NodeReference>
@@ -1536,7 +1536,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="179,240,82,95" Id="BgNNnDaO2vCP87VblSiBk1">
-                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationCallFlag" Name="Where" />
                     <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -1549,7 +1549,7 @@
                     <ControlPoint Id="GZdEfP6S4nGOnCbUpCDnqs" Bounds="193,248" />
                     <ControlPoint Id="BXGx482ovWVMaGSBhVGV4N" Bounds="193,328" />
                     <Node Bounds="191,264,58,26" Id="NxTjVwn7Qn7Mj9WKGNTQQS">
-                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Nullable" />
                         <Choice Kind="OperationCallFlag" Name="HasValue" />
@@ -1563,7 +1563,7 @@
               </Patch>
             </Node>
             <Node Bounds="146,156,82,26" Id="Ul8ka3In1fOO7Kj3C57imz">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetCalibration" />
                 <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -1573,22 +1573,6 @@
               <Pin Id="KaIxv6HbHjWOTiB14bJgTz" Name="Calibration" Kind="OutputPin" />
             </Node>
           </Canvas>
-          <Patch Id="BemAYTCrdadPql1Hlq044A" Name="Create" />
-          <Patch Id="LK0mNDQngZQOcaLgcnJjtW" Name="Update">
-            <Pin Id="UZzzVWHDcrPOkhQSJePjJg" Name="Device" Kind="InputPin" Bounds="180,751" />
-            <Pin Id="U1TiSjGB5tEP1zH7PoCuin" Name="Output" Kind="OutputPin" Bounds="104,965" />
-            <Pin Id="EArICKFvPg7LyVWrsoj7ua" Name="Minimum Z" Kind="InputPin" Bounds="630,576" />
-            <Pin Id="RGFrNUqrudDMGGTJhnV7Wg" Name="Maximum Z" Kind="InputPin" Bounds="693,580" DefaultValue="8">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Float32" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="AN5OneldsAtNqLdMYMIxio" Name="Decimation" Kind="InputPin" Bounds="767,586" DefaultValue="4">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pin>
-          </Patch>
           <ProcessDefinition Id="KRA47n0T9skMGd7xyUNPN8">
             <Fragment Id="VzRlKwtueWZOZUYvIdIcq4" Patch="BemAYTCrdadPql1Hlq044A" Enabled="true" />
             <Fragment Id="BGkghZyHlTWPpJQKoYZSol" Patch="LK0mNDQngZQOcaLgcnJjtW" Enabled="true" />
@@ -1641,6 +1625,22 @@
           <Link Id="HyOBjHkzAycMXy2bSRqSu2" Ids="VOSZxMhcSvuMYbUq3KhdoH,HMnJ6hpY8XSQMcyy6D1Xrw" />
           <Link Id="V48ntBFADBUL2MfbR0cjkR" Ids="Bii8BLYcQvlOufTwgtDzV5,StNO42EEkePNR8iEtIQm4W" />
           <Link Id="IThJPPSFyqAM0sc7CwY6jJ" Ids="StNO42EEkePNR8iEtIQm4W,CnBSThIRNGMPKAzDUK3rhR" />
+          <Patch Id="BemAYTCrdadPql1Hlq044A" Name="Create" />
+          <Patch Id="LK0mNDQngZQOcaLgcnJjtW" Name="Update">
+            <Pin Id="UZzzVWHDcrPOkhQSJePjJg" Name="Device" Kind="InputPin" Bounds="180,751" />
+            <Pin Id="EArICKFvPg7LyVWrsoj7ua" Name="Minimum Z" Kind="InputPin" Bounds="630,576" />
+            <Pin Id="RGFrNUqrudDMGGTJhnV7Wg" Name="Maximum Z" Kind="InputPin" Bounds="693,580" DefaultValue="8">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="AN5OneldsAtNqLdMYMIxio" Name="Decimation" Kind="InputPin" Bounds="767,586" DefaultValue="4">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="U1TiSjGB5tEP1zH7PoCuin" Name="Output" Kind="OutputPin" Bounds="104,965" />
+          </Patch>
         </Patch>
       </Node>
       <Canvas Id="EceBQLK7pkJPsPUtl0HuKu" Name="Internal" Position="120,179">
@@ -1698,7 +1698,7 @@
             <Choice Kind="ForwardDefinition" Name="Forward" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
-          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
             <Choice Kind="TypeFlag" Name="Capture" />
           </p:TypeAnnotation>
           <Patch Id="Ja82rEuVGLUN9OMoA2uGot">
@@ -1721,12 +1721,12 @@
 
 -->
         <Node Name="FromVector3" Bounds="635,310,134,237" Id="ODIFFi0fTVXMFmcJcsVyun">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="EWSMIlUDZ3NPjMosh8zAvR">
             <Node Bounds="647,476,46,26" Id="AuFQG1ERygsO8Yiw1prmHO">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
@@ -1740,7 +1740,7 @@
             <ControlPoint Id="AWdDWSLWyHPNZD9OBMmLhV" Bounds="649,530" />
             <Link Id="AE3xzHUU9V2NHEZsLJUwZK" Ids="AWdDWSLWyHPNZD9OBMmLhV,ApkW6S1yKIzNiPsq9vnAIB" IsHidden="true" />
             <Node Bounds="647,436,46,19" Id="QVtoXedWl0DOTTquynwgSm">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Vector3Type" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Split)" />
@@ -1757,7 +1757,7 @@
             <Link Id="GAOIOwA758uOoxn6gKp23Y" Ids="Doa7pCjeWlyLpfwff5O3Ex,VikmJ2HVUCtLa64zyiQeNw" IsHidden="true" />
             <Link Id="VTP7DLqpuBULerkIT2aYW6" Ids="PLe0Ru8GvOVLrvWyzFoieZ,AWdDWSLWyHPNZD9OBMmLhV" />
             <Node Bounds="648,392,25,19" Id="DWsFD8rRa5xMxcbH74ew1m">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -1768,7 +1768,7 @@
             <Link Id="QkR3VKd6ycwLqlj0zfbSSp" Ids="VikmJ2HVUCtLa64zyiQeNw,HHT29yeQh7aQZ8OSOSMDZE" />
             <Link Id="VIng0xcNvmeNMPlY48P1Jo" Ids="EKX4psO8tYKPy0L9MmLEsk,G03a7bRUUuHP3MiVF1tnS0" />
             <Pad Id="NsOQFK8sqZ5O504GTDJneb" Comment="" Bounds="700,364,38,43" ShowValueBox="true" isIOBox="true" Value="1000, -1000, 1000">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -1786,7 +1786,7 @@
 
 -->
         <Node Name="ToVector3" Bounds="356,301,215,267" Id="IrYrsKkgfqdOOW3X0l2V1I">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="UdBMtkkKrpFMWxDqmLO14e">
@@ -1795,7 +1795,7 @@
             <ControlPoint Id="Hv0o4r9cVJ6QHgwWFvSPyg" Bounds="370,319" />
             <Link Id="MDdPiUCqim2LUxECBg1d9T" Ids="IFTFZK0mNKXN34aoJhH2g8,Hv0o4r9cVJ6QHgwWFvSPyg" IsHidden="true" />
             <Node Bounds="369,342,44,26" Id="KwnPufXTOx1O8VxNzbFK4x">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="X" />
@@ -1806,7 +1806,7 @@
             </Node>
             <Link Id="PmkfMpu05HVLI30Tx7rtqb" Ids="Hv0o4r9cVJ6QHgwWFvSPyg,LUTR1wp87xOMMe7oUYwbnz" />
             <Node Bounds="369,378,44,26" Id="UG2KLAmeoe6LRRzhe2JHKg">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Y" />
@@ -1816,7 +1816,7 @@
               <Pin Id="G6EuI2jLMc3QShKQbVjcmU" Name="Y" Kind="OutputPin" />
             </Node>
             <Node Bounds="369,415,44,26" Id="Jbq9s13oFVPLIufK7eHY9I">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Z" />
@@ -1828,7 +1828,7 @@
             <Link Id="OpDyACPN1RUMil7j06B7hs" Ids="MLd79iJZPkELw8AAKREWhP,U6stE3RylfKMPCPrGCvaeD" />
             <Link Id="Hc1wDmD4B5APD671PZcveu" Ids="VYQShzWe6QrP1amyfNvEUy,V7mZL3lp6QWLAGhbnOmVpz" />
             <Node Bounds="441,462,46,19" Id="OY8Hic75mugMDmB4Pgi1sf">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Vector3Type" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -1842,7 +1842,7 @@
             <Link Id="URCYMbjA8SxOgMeRh6MgxN" Ids="C1cwUtNVQOYNHacdZIRdj6,AMJQh0iUWj2MNmdmUhsjT1" />
             <Link Id="J9ICNqwHo1NOyA8FwAw62z" Ids="SViIwj1ukA1Lnccjsdmf4q,RtKS3K4dLlVQATVKYdl4mY" />
             <Node Bounds="444,502,25,19" Id="K3NeTAzZSDjLLYwd9L97tR">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -1851,7 +1851,7 @@
               <Pin Id="NH6tMEFr6mwPzDWhBfSl8S" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="P194hVwy53HPfLr7UVAoQy" Comment="" Bounds="497,445,43,43" ShowValueBox="true" isIOBox="true" Value="0.001, -0.001, 0.001">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -1871,12 +1871,12 @@
 
 -->
         <Node Name="FromQuaternion" Bounds="741,643,251,277" Id="RaKIHm0Upc4NkpSBUbcWPU">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="A8g7tqAmnJpPziGJCEn5R6">
             <Node Bounds="757,843,65,26" Id="HdHznE8DkNiOZOywwJOMYK">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
                 <CategoryReference Kind="AssemblyCategory" Name="Quaternion" NeedsToBeDirectParent="true" />
@@ -1891,7 +1891,7 @@
             <ControlPoint Id="UpIuSYHQfaOLIccHD1SoXd" Bounds="760,903" />
             <Link Id="PwKBtOCkKhlL5FgumnUQmq" Ids="UpIuSYHQfaOLIccHD1SoXd,CGMtpOvUmvBNvrhlRv7gW4" IsHidden="true" />
             <Node Bounds="757,803,67,19" Id="Ua71PYJ92KaMKUPap8ZVuk">
-              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="Quaternion (Split)" />
@@ -1910,27 +1910,27 @@
             <Link Id="FfpNLTuPSkBNqhUxTKrw3v" Ids="TrdYfjXBXI0PJkoWumBXVe,UpIuSYHQfaOLIccHD1SoXd" />
             <Link Id="A4aVWgDbC9kN721LSJLf1r" Ids="PsrmsFsdO04NGPKg6XLJAS,BJfutrNtH1QQTI9Q0x7Aj9" />
             <Node Bounds="819,729,74,19" Id="KsuYj1hv60TNFwhuGRjAoc">
-              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="RotationAxis" />
               </p:NodeReference>
               <Pin Id="HKpObrX2WDcP0augxThdtU" Name="Axis" Kind="InputPin" />
               <Pin Id="HFn2zScHTpGOvmLjDWt5Dw" Name="Angle" Kind="InputPin" DefaultValue="-0.5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LLWDpUeaGLwMcXwktYh96f" Name="Result" Kind="OutputPin" />
             </Node>
             <Pad Id="LT3JQ7VZG72MGYNcIOgcDf" Comment="Axis" Bounds="823,686,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 0">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="BkZj00jEDyJMRoEDujKWtk" Ids="LT3JQ7VZG72MGYNcIOgcDf,HKpObrX2WDcP0augxThdtU" />
             <Node Bounds="760,761,25,19" Id="BZzmGZVNW4TQKzMD8LItbA">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -1942,7 +1942,7 @@
             <Link Id="HYaGmdZ7ZeBMCGjJZLRM9j" Ids="LLWDpUeaGLwMcXwktYh96f,ICGRajnNptSLbZqTCZASP9" />
             <Link Id="LdatWheegc1LHtvryFGXMI" Ids="Ux1XqUPBAHuOXzvExuHV9u,CCnnq9nHAC2OGN5Khl8Ke8" />
             <Pad Id="SYmcwPXy9aDOc6FYxMtNfr" Comment="Angle" Bounds="897,714,35,15" ShowValueBox="true" isIOBox="true" Value="-0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
@@ -1957,7 +1957,7 @@
 
 -->
         <Node Name="ToQuaternion" Bounds="360,645,341,410" Id="Ez0vj09VHBMPqYzlCcsgV2">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="LCMnbIuoFeXNmuXHWxSVcK">
@@ -1966,7 +1966,7 @@
             <ControlPoint Id="NaTPejKxVFMPfIgW7pr8xF" Bounds="374,663" />
             <Link Id="NciQRv5cDE3LW9zGCPkixh" Ids="R9iqiro4FmbNkoUrK6V48q,NaTPejKxVFMPfIgW7pr8xF" IsHidden="true" />
             <Node Bounds="373,686,56,26" Id="HovuaNO5JI9N9oZKUVp0fx">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="X" />
                 <CategoryReference Kind="AssemblyCategory" Name="Quaternion" NeedsToBeDirectParent="true" />
@@ -1977,7 +1977,7 @@
             </Node>
             <Link Id="LyfSQNr4EYSPs79gly7Qjg" Ids="NaTPejKxVFMPfIgW7pr8xF,STKaifWyLn0Lg2ocHxUenU" />
             <Node Bounds="373,722,56,26" Id="SQvYbKO3IvWOCS8brZeCz3">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Y" />
                 <CategoryReference Kind="AssemblyCategory" Name="Quaternion" NeedsToBeDirectParent="true" />
@@ -1987,7 +1987,7 @@
               <Pin Id="IWUSFyffYIDOnart3nsbBC" Name="Y" Kind="OutputPin" />
             </Node>
             <Node Bounds="373,759,56,26" Id="L87fw3PSmCuNvVZwbLJPHT">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="Z" />
@@ -1999,7 +1999,7 @@
             <Link Id="JR9g60VBk7qOedFlERxFeW" Ids="ANTKk8iNzVvNOm6O2HqLDl,Egs0ygd02XrMScMvwUQ2wJ" />
             <Link Id="VHK8Ypjj3zWMh2PgWQjbPO" Ids="PvCqzEfDDAqQJlXbLHvrZc,JyAK0LeO4idLQRkST7amOU" />
             <Node Bounds="373,801,56,26" Id="Db0adOixElxLaRSDAKgvu0">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Quaternion" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="W" />
@@ -2010,7 +2010,7 @@
             </Node>
             <Link Id="UTHzuvAgoCNMkiHjeUKT2D" Ids="NiK9Ly9Yl8ZQWLytyhZdfP,NroWBxkSswuQOKtcfoceHd" />
             <Node Bounds="454,867,67,19" Id="S6wn5zQXECMQReW9YSkGlO">
-              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="Quaternion (Join)" />
@@ -2026,21 +2026,21 @@
             <Link Id="MxIW75c9OXCNrvBsUfyGHX" Ids="Jpyn4ZyRzjNQYzWXUCByyN,Ce6feVx1q9ONXjv41BwGEp" />
             <Link Id="PvPVGmOSoVGQFOyCMh3IBm" Ids="KAjp2z8PaD3LLErDnw2V4G,IAMFgDXALnZPs2Lg9gR4tU" />
             <Node Bounds="528,938,74,19" Id="Qgfx72Gwrd4NO5HhfmzK8S">
-              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Quaternion" />
                 <Choice Kind="OperationCallFlag" Name="RotationAxis" />
               </p:NodeReference>
               <Pin Id="LDV1RZwdfZDOgpwRrldtUW" Name="Axis" Kind="InputPin" />
               <Pin Id="EI25O0l2s71NVJY0ioEHXX" Name="Angle" Kind="InputPin" DefaultValue="0.5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="R0RQl4B1dRTNLrG0y4PO3V" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="452,973,25,19" Id="O1j7rjASGowP2v2uxCbyMG">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -2049,7 +2049,7 @@
               <Pin Id="UVmiIuLSKTtLtnqKmA7BYn" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="BmgQdq1fHPzLSRyRRhjsnH" Comment="Axis" Bounds="532,895,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 0">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
@@ -2058,7 +2058,7 @@
             <Link Id="IvgCDDguGBCQKmPcSNWUNc" Ids="Cqi3KYCmV55OULFZoDcmHA,AOAI33cViX9NuUxPz2o0r6" />
             <Link Id="CqQS7MPCqawOMMcq5QIfmV" Ids="UVmiIuLSKTtLtnqKmA7BYn,O6IxMLNqMKTOoGMNQJAFIw" />
             <Pad Id="Jmoe6vDeEaRL3UkWqTADRC" Comment="Angle" Bounds="606,914,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
@@ -2073,7 +2073,7 @@
 
 -->
         <Node Name="ToVector2" Bounds="959,300,143,224" Id="Hmm67gfxbwPMLprSCodf6B">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="CfaNnhyopPCMwiDy2VLX6p">
@@ -2082,7 +2082,7 @@
             <ControlPoint Id="HHmIwYwxP4COGzNFff47K0" Bounds="973,318" />
             <Link Id="Ihl11UkPYcaPZYL5GY5FD3" Ids="JTdxRrYeVABOgLUVlNjXa4,HHmIwYwxP4COGzNFff47K0" IsHidden="true" />
             <Node Bounds="972,340,44,26" Id="KrfMWcNCBzjMMCzgRtaPI3">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector2" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector2" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="X" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -2093,7 +2093,7 @@
             </Node>
             <Link Id="B42y7I7kPgAMEVsgp15aqx" Ids="HHmIwYwxP4COGzNFff47K0,MaZofAhFr5eNbIqLggW8ME" />
             <Node Bounds="973,387,44,26" Id="LqJg7JEISeWM45Aotlqt8J">
-              <p:NodeReference LastCategoryFullName="System.Numerics.Vector2" LastSymbolSource="System.Numerics.Vectors.dll">
+              <p:NodeReference LastCategoryFullName="System.Numerics.Vector2" LastDependency="System.Numerics.Vectors.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Y" />
                 <CategoryReference Kind="AssemblyCategory" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -2103,7 +2103,7 @@
               <Pin Id="DUw61Qp8NdhNfiJH3T6I0C" Name="Y" Kind="OutputPin" />
             </Node>
             <Node Bounds="1044,461,46,19" Id="GWsdVhrdObWOjEesPne53V">
-              <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                 <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -2128,39 +2128,15 @@
 
 -->
         <Node Name="ColorImage (Reactive)" Bounds="267,399" Id="T74ow3n3RVOLYbFCzh6ELg">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="H1oPNBtOuSsQF9VxtodIJu">
             <Canvas Id="CtmTOSZQJiZMiewLc5Utwm" CanvasType="Group">
-              <ControlPoint Id="NsXHxe2UQqdPzkDPzqHfYD" Bounds="378,215" />
-              <ControlPoint Id="CuU1skZoTCvL89eUA1Y1Mb" Bounds="379,495" />
-              <Node Bounds="366,307,124,142" Id="QgFOoEYhxnVM30WDb9qkte">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="CFmi537GPp9L3z4xOyovI8" Name="Force" Kind="InputPin" />
-                <Pin Id="KMYC8A1jCthLmry4MnF6mu" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="PsYVTpBanJhP3ac7U6sfUK" Name="Has Changed" Kind="OutputPin" />
-                <Patch Id="Dm4er0tBaDjMEU1OL0wkrI" ManuallySortedPins="true">
-                  <Patch Id="IL1SMkY4zdzLIvafs3Ejdw" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="PNotS9rIblWL4Oujs51WuY" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="378,330,100,26" Id="FOJOvnJApyWLq9LzMHPfnI">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="SelectColorImages" />
-                    </p:NodeReference>
-                    <Pin Id="Thnh9rnMTrgQStLt49b5vQ" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="NpjGb4f7k1FLNrv6u6Hn5t" Name="Output" Kind="OutputPin" />
-                  </Node>
-                </Patch>
-                <ControlPoint Id="IzZw6nnkMM9NKST9fKVKnV" Bounds="380,443" Alignment="Bottom" />
-                <ControlPoint Id="DmxyjoGO6LDQJMolBVb97Q" Bounds="379,314" Alignment="Top" />
-              </Node>
+              <ControlPoint Id="NsXHxe2UQqdPzkDPzqHfYD" Bounds="377,215" />
+              <ControlPoint Id="CuU1skZoTCvL89eUA1Y1Mb" Bounds="377,420" />
               <Node Bounds="375,254,85,26" Id="ECl7qSITU7GLwlPejG2JNC">
-                <p:NodeReference>
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCaptures" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -2168,6 +2144,30 @@
                 <Pin Id="NEhBfZ3PvOWP1PlpOsVlaG" Name="Input" Kind="StateInputPin" />
                 <Pin Id="GEskgpzL80OL55byI4P9TV" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="L7KEU8fAB5IOmkDPU4BjhX" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="363,305,124,86" Id="IEEg7DExXkYNUWukQ4DUx6">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="Jopmx0WlOhbOvBYVJE90j6" Name="Force" Kind="InputPin" />
+                <Pin Id="CV1zv1mWmzFOP4JikIfeUt" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="Vb5o1nTLXf0LbDNt7efPhO" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="VRqAKsl23b7OLlLEx58Mqz" ManuallySortedPins="true">
+                  <Patch Id="Fp1pEqgLCu7Mu6prvHCNTh" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="QGPLaRRmjg3MIZnSvOE1Gv" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="375,332,100,26" Id="FOJOvnJApyWLq9LzMHPfnI">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectColorImages" />
+                    </p:NodeReference>
+                    <Pin Id="Thnh9rnMTrgQStLt49b5vQ" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="NpjGb4f7k1FLNrv6u6Hn5t" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="VJK2iV93FqVNObNutbmSNu" Bounds="377,311" Alignment="Top" />
+                <ControlPoint Id="GMLX9tsKTq6NU4GqU6w2nU" Bounds="377,385" Alignment="Bottom" />
               </Node>
             </Canvas>
             <Patch Id="Kdz0qnbYjI6Pb82li2jumJ" Name="Create" />
@@ -2182,10 +2182,10 @@
             <Link Id="An5YqL2j6lCOMu2T4TnD6r" Ids="MJ152JxFFaaMTHctacABMC,NsXHxe2UQqdPzkDPzqHfYD" IsHidden="true" />
             <Link Id="CEpzUukGMRpPdWdxXNrpj8" Ids="CuU1skZoTCvL89eUA1Y1Mb,Ei31w99LBksPKQze8p7sCf" IsHidden="true" />
             <Link Id="SspFUB3aVclPuBjxgTYtKn" Ids="NsXHxe2UQqdPzkDPzqHfYD,NEhBfZ3PvOWP1PlpOsVlaG" />
-            <Link Id="GFjYXRj3X9JLLOYiAYOzBQ" Ids="L7KEU8fAB5IOmkDPU4BjhX,DmxyjoGO6LDQJMolBVb97Q" />
-            <Link Id="KBLnuL9yag8Nin8WFkArzy" Ids="DmxyjoGO6LDQJMolBVb97Q,Thnh9rnMTrgQStLt49b5vQ" />
-            <Link Id="I55p4bO03ETNPS3LWliKiW" Ids="NpjGb4f7k1FLNrv6u6Hn5t,IzZw6nnkMM9NKST9fKVKnV" />
-            <Link Id="IX66KACJxEvPyDH799JXRS" Ids="IzZw6nnkMM9NKST9fKVKnV,CuU1skZoTCvL89eUA1Y1Mb" />
+            <Link Id="Bv37tYM3MBWLxtAgNMqRiG" Ids="L7KEU8fAB5IOmkDPU4BjhX,VJK2iV93FqVNObNutbmSNu" />
+            <Link Id="HM8hgpCI42aQdgG2V7tQD2" Ids="NpjGb4f7k1FLNrv6u6Hn5t,GMLX9tsKTq6NU4GqU6w2nU" />
+            <Link Id="ORMa3KdfCgvLGbG2lebjN3" Ids="GMLX9tsKTq6NU4GqU6w2nU,CuU1skZoTCvL89eUA1Y1Mb" />
+            <Link Id="HR4wB0SQE1IL0W4u7psj0v" Ids="VJK2iV93FqVNObNutbmSNu,Thnh9rnMTrgQStLt49b5vQ" />
           </Patch>
         </Node>
         <!--
@@ -2194,39 +2194,15 @@
 
 -->
         <Node Name="DepthImage (Reactive)" Bounds="267,492" Id="KF272zdSMZsPxH9v2bR51V">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="R7hHlWYGsukNNWElb33yBM">
             <Canvas Id="CB0gkF58gsSMyJhN5fv8Iu" CanvasType="Group">
-              <ControlPoint Id="RFILjl9ksRjLnDFaDnhtZ9" Bounds="447,226" />
-              <ControlPoint Id="MWd922eiCh1M6vs2ATpNrR" Bounds="455,437" />
-              <Node Bounds="441,304,127,94" Id="H9yigmiF6ApPrxXdhR4ej9">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="ToPU5plbcA5McALoe7XiNm" Name="Force" Kind="InputPin" />
-                <Pin Id="Dy6HdKI1iBuN7rA61SYjmW" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="RQf9T6Cwxs8NGAuP3FeExw" Name="Has Changed" Kind="OutputPin" />
-                <Patch Id="SkyOs8fwwCeLvdKI0Dto6S" ManuallySortedPins="true">
-                  <Patch Id="UM8qA7r17PZLqkxlysDbgY" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="SVyftd3qt3BPmKW9mXU7qF" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="453,335,103,26" Id="MILHkbyR3PPNwXnHZi8FVW">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="SelectDepthImages" />
-                    </p:NodeReference>
-                    <Pin Id="T6OpbhFUDvQMuObH1meScq" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="U4fEOQYn4TJO66kdEE4SyJ" Name="Output" Kind="OutputPin" />
-                  </Node>
-                </Patch>
-                <ControlPoint Id="SuudBjW7Ey5M8xQNvBooIO" Bounds="454,392" Alignment="Bottom" />
-                <ControlPoint Id="DMMsqsbcbhMNXGYWb4brol" Bounds="455,310" Alignment="Top" />
-              </Node>
-              <Node Bounds="442,250,85,26" Id="Oh8SJPkKIkZPeoBAwAlrns">
-                <p:NodeReference>
+              <ControlPoint Id="RFILjl9ksRjLnDFaDnhtZ9" Bounds="443,226" />
+              <ControlPoint Id="MWd922eiCh1M6vs2ATpNrR" Bounds="442,437" />
+              <Node Bounds="441,250,85,26" Id="Oh8SJPkKIkZPeoBAwAlrns">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCaptures" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -2234,6 +2210,30 @@
                 <Pin Id="Eli1VFT60czOOEfKJqZX12" Name="Input" Kind="StateInputPin" />
                 <Pin Id="K1ehTG9gviAOW8x0U9xEOQ" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="PFsu6eoTrYiOovuszE4SU0" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="428,300,128,86" Id="U0GqO9wR56HLlejjEqqad3">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="InMud1OF7c1PM6bEH76IKn" Name="Force" Kind="InputPin" />
+                <Pin Id="Ks2rDuZ8bCzMzqwaG8tVty" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="LXqwLm58mAHNp9wynnCCYD" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="HmJ0UO2geJBMThmeXzv2T3" ManuallySortedPins="true">
+                  <Patch Id="ABt5KrdFcCXLQscFn2Zoy4" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="RHda5v4Y76tLIurWu5CuTh" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="440,332,103,26" Id="MILHkbyR3PPNwXnHZi8FVW">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectDepthImages" />
+                    </p:NodeReference>
+                    <Pin Id="T6OpbhFUDvQMuObH1meScq" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="U4fEOQYn4TJO66kdEE4SyJ" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="C7ANoD4n0MmOrqpvFZUaFs" Bounds="442,306" Alignment="Top" />
+                <ControlPoint Id="GrYaXuDEqSvNniC33aRZBO" Bounds="442,380" Alignment="Bottom" />
               </Node>
             </Canvas>
             <Patch Id="M8OK4W8XqeNMFzIA6cvusQ" Name="Create" />
@@ -2247,11 +2247,11 @@
             </ProcessDefinition>
             <Link Id="De9oeRT2GFVPXNQ7EcrASh" Ids="GhjsZpqz5BFPBNgKjSpMbs,RFILjl9ksRjLnDFaDnhtZ9" IsHidden="true" />
             <Link Id="DUdyzAlKFOMOrf1fZMzFok" Ids="MWd922eiCh1M6vs2ATpNrR,Drq8HwnqHJfPNNg1IdiQgO" IsHidden="true" />
-            <Link Id="FQ9eP6ap3CWNEWxVsI5bVz" Ids="U4fEOQYn4TJO66kdEE4SyJ,SuudBjW7Ey5M8xQNvBooIO" />
             <Link Id="TqIGcBQCpDgO6zGOrppnTU" Ids="RFILjl9ksRjLnDFaDnhtZ9,Eli1VFT60czOOEfKJqZX12" />
-            <Link Id="PytuEiZcbF1N9KAE6B5KHc" Ids="PFsu6eoTrYiOovuszE4SU0,DMMsqsbcbhMNXGYWb4brol" />
-            <Link Id="FduSoTd2gIaQPGqwgd6MMr" Ids="DMMsqsbcbhMNXGYWb4brol,T6OpbhFUDvQMuObH1meScq" />
-            <Link Id="GyAXuHVyQ2UOaD3BZuaXQc" Ids="SuudBjW7Ey5M8xQNvBooIO,MWd922eiCh1M6vs2ATpNrR" />
+            <Link Id="GC2BSLYjtSrMLYU2wsRUJQ" Ids="PFsu6eoTrYiOovuszE4SU0,C7ANoD4n0MmOrqpvFZUaFs" />
+            <Link Id="CDUWdjXu18MN8SW9Rsl7dp" Ids="C7ANoD4n0MmOrqpvFZUaFs,T6OpbhFUDvQMuObH1meScq" />
+            <Link Id="UUnHAczmrGtQOL3FHkEbvK" Ids="U4fEOQYn4TJO66kdEE4SyJ,GrYaXuDEqSvNniC33aRZBO" />
+            <Link Id="HtvTKriVWgRM0F7CDrvcNF" Ids="GrYaXuDEqSvNniC33aRZBO,MWd922eiCh1M6vs2ATpNrR" />
           </Patch>
         </Node>
         <!--
@@ -2260,39 +2260,15 @@
 
 -->
         <Node Name="InfraredImage (Reactive)" Bounds="267,445" Id="GAGlMqQ6jZ4MGC95RKIp9M">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="DDbhse6GhSyQQ1RTAq3ZDq">
             <Canvas Id="VgtFMX08FNJMJTkdbjyxK0" CanvasType="Group">
-              <ControlPoint Id="SXcbMU73esrPwdS1qeowSW" Bounds="378,215" />
-              <ControlPoint Id="GpU25v6MC0OMjxHUSkgs0W" Bounds="380,444" />
-              <Node Bounds="366,307,135,92" Id="IPeJnfaHSh0QM5GF5oexxN">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="Ddnwk8HUJ5GM0sEjLstzgd" Name="Force" Kind="InputPin" />
-                <Pin Id="Mk9l7h6h9OxL47d6DIqFuF" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="M6V0BdmgdogQU78Rwqcjve" Name="Has Changed" Kind="OutputPin" />
-                <Patch Id="HRlEUAMdlcNQPVlsaRBBNC" ManuallySortedPins="true">
-                  <Patch Id="PoHFpgVd4ylOSfVkIhFnPY" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="A0QexEyzwFPOqBTsu9cJFw" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="378,330,100,26" Id="EVGlK21yUQUO50D0j7xE8L">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="SelectInfraredImages" />
-                    </p:NodeReference>
-                    <Pin Id="FUXWUZOl309OPvY4X3VotZ" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="Ug2zNGqcPaAMnmuqLJQ6Vp" Name="Output" Kind="OutputPin" />
-                  </Node>
-                </Patch>
-                <ControlPoint Id="MOY0kt51i3gPvmE5C6sQqI" Bounds="381,393" Alignment="Bottom" />
-                <ControlPoint Id="PQNIIMfHRwpOdgl2ewXc5y" Bounds="379,314" Alignment="Top" />
-              </Node>
-              <Node Bounds="375,254,85,26" Id="NzQjNXeG0H4PGczNUUxHl3">
-                <p:NodeReference>
+              <ControlPoint Id="SXcbMU73esrPwdS1qeowSW" Bounds="377,200" />
+              <ControlPoint Id="GpU25v6MC0OMjxHUSkgs0W" Bounds="377,414" />
+              <Node Bounds="375,239,85,26" Id="NzQjNXeG0H4PGczNUUxHl3">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCaptures" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -2300,6 +2276,30 @@
                 <Pin Id="J9A6EkABfidOpL9ZeqeiYy" Name="Input" Kind="StateInputPin" />
                 <Pin Id="TEnCUoED5ReL9dhYkXUitW" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="D0wMeftUUuCOb1nbM37WuS" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="363,296,135,86" Id="VC1cmdOawnkNb4jZ6XIUgY">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="FzeNTUncXrvOF2AZS9pc9K" Name="Force" Kind="InputPin" />
+                <Pin Id="MHuHT2sJO2KNQfbnEU0gsU" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="NMlJCRXsnTfNlUme9WmRIq" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="SZUWpRKsyx8LNNfBfXwjzd" ManuallySortedPins="true">
+                  <Patch Id="LAVUiyHBotXOt5grKmEhkJ" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="Iw9tbVs8z95QVDgN33aLt0" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="375,325,111,26" Id="EVGlK21yUQUO50D0j7xE8L">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectInfraredImages" />
+                    </p:NodeReference>
+                    <Pin Id="FUXWUZOl309OPvY4X3VotZ" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Ug2zNGqcPaAMnmuqLJQ6Vp" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="MRZhvApsSbLP3He7r3P411" Bounds="377,302" Alignment="Top" />
+                <ControlPoint Id="BSzowFQfoqOMHNMBNp3wzQ" Bounds="377,376" Alignment="Bottom" />
               </Node>
             </Canvas>
             <Patch Id="Rjp1jB1wOIyPa5qDhgp3xX" Name="Create" />
@@ -2314,10 +2314,10 @@
             <Link Id="MKyYpgMP2s8NWxF5AMX7IM" Ids="JGdZveUDeEvMRcVe9XPqgz,SXcbMU73esrPwdS1qeowSW" IsHidden="true" />
             <Link Id="GPDZxKgRkgHN5URVLMFTpH" Ids="GpU25v6MC0OMjxHUSkgs0W,IMFgmz7JgucOywjXtcP2lk" IsHidden="true" />
             <Link Id="VUrhDCUWmAaMTFk43DoKWF" Ids="SXcbMU73esrPwdS1qeowSW,J9A6EkABfidOpL9ZeqeiYy" />
-            <Link Id="SViMpwfZOn5Mv7xiGqwUAZ" Ids="D0wMeftUUuCOb1nbM37WuS,PQNIIMfHRwpOdgl2ewXc5y" />
-            <Link Id="DZAGvKKKXQ3My95xgtzT4Y" Ids="PQNIIMfHRwpOdgl2ewXc5y,FUXWUZOl309OPvY4X3VotZ" />
-            <Link Id="GopKIzjioL5N9OR65sdEn8" Ids="Ug2zNGqcPaAMnmuqLJQ6Vp,MOY0kt51i3gPvmE5C6sQqI" />
-            <Link Id="JAIbTUs3EaqO0eLUubeQ27" Ids="MOY0kt51i3gPvmE5C6sQqI,GpU25v6MC0OMjxHUSkgs0W" />
+            <Link Id="JyjKnGXdlZeMSk9fSyD0Yj" Ids="D0wMeftUUuCOb1nbM37WuS,MRZhvApsSbLP3He7r3P411" />
+            <Link Id="TqvGanUvypvLoYoDklouME" Ids="MRZhvApsSbLP3He7r3P411,FUXWUZOl309OPvY4X3VotZ" />
+            <Link Id="NV0sBvFvAAXPTPPRg14dkB" Ids="Ug2zNGqcPaAMnmuqLJQ6Vp,BSzowFQfoqOMHNMBNp3wzQ" />
+            <Link Id="IYs9zg2yljoOJe2jvU4ulR" Ids="BSzowFQfoqOMHNMBNp3wzQ,GpU25v6MC0OMjxHUSkgs0W" />
           </Patch>
         </Node>
         <!--
@@ -2326,13 +2326,13 @@
 
 -->
         <Node Name="IMUData (Reactive)" Bounds="550,398" Id="FvN2kKAc4KdLOnMehHY0Lt">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="PKRAEQ6v0BYQA9rtEE8AnD">
             <Canvas Id="Lxv16AT4XGCNK1aGq77mUd" CanvasType="Group">
               <Node Bounds="81,239,87,26" Id="LyMmFhXtJlEMogphlPOxEi">
-                <p:NodeReference>
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" />
                   <Choice Kind="OperationCallFlag" Name="GetImuSamples" />
@@ -2365,7 +2365,7 @@
 
 -->
         <Node Name="IDevice" Bounds="267,272" Id="IiB6IHBc7hKQCOkb1tvORM">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="InterfaceDefinition" Name="Interface" />
           </p:NodeReference>
           <Patch Id="GVB32FFNdfJM5VoMyCHhK8">
@@ -2378,12 +2378,12 @@
 
 -->
               <Node Name="CreateDefault" Bounds="829,232,124,103" Id="TA4iqf663pTMKcX7PYDaO2">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
                 <Patch Id="F3etO6jEwTjMLftDsGbNHa">
                   <Node Bounds="862,266,79,26" Id="DPeoCBfzOy4O4vEuY2jb1B">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.DummyDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.DummyDevice" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="DummyDevice" />
                       <Choice Kind="OperationCallFlag" Name="CreateDefault" />
@@ -2405,9 +2405,12 @@
               <Fragment Id="D9lwVR2dPOLPgELZweOzkj" Patch="QmFOzesdYpkN9vTPPXvj1I" Enabled="true" />
               <Fragment Id="RwQuSp3rjNcMokJz757USu" Patch="AWduGflYifQOVpLLPBmpgk" />
             </ProcessDefinition>
+            <Link Id="Qv62VqOfAWON7no6nAGMOL" Ids="EzF0KBfDDIaLyyA770ySsi,ST4RpDQnZgCNDJ5crCB3lb" IsHidden="true" />
+            <Link Id="N1kasFi7iIrONsAz7NHz4K" Ids="UqqGDKvyQqBPcvOikaIVy1,VIfOK1YGAQwLU8Kt7dU1OM" IsHidden="true" />
+            <Link Id="JgkVSin6zQ0OXM8olKv3Er" Ids="FdAKiwrxeM9MpjtJzlp7mK,BZ4HKAWlxujP565J93Ep2Z" IsHidden="true" />
             <Patch Id="QmFOzesdYpkN9vTPPXvj1I" Name="GetCaptures">
               <Pin Id="ST4RpDQnZgCNDJ5crCB3lb" MergeId="284960" Name="Captures" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Observable" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -2419,10 +2422,9 @@
               </Pin>
             </Patch>
             <Patch Id="RaRnOjMnN1YMzoeSrIEl6l" Name="GetDevice" />
-            <Link Id="Qv62VqOfAWON7no6nAGMOL" Ids="EzF0KBfDDIaLyyA770ySsi,ST4RpDQnZgCNDJ5crCB3lb" IsHidden="true" />
             <Patch Id="Sa5xrSWunDJN6q9l63ZcTb" Name="GetImuSamples">
               <Pin Id="VIfOK1YGAQwLU8Kt7dU1OM" MergeId="261271" Name="Samples" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Observable" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -2432,10 +2434,9 @@
                 </p:TypeAnnotation>
               </Pin>
             </Patch>
-            <Link Id="N1kasFi7iIrONsAz7NHz4K" Ids="UqqGDKvyQqBPcvOikaIVy1,VIfOK1YGAQwLU8Kt7dU1OM" IsHidden="true" />
             <Patch Id="AWduGflYifQOVpLLPBmpgk" Name="GetCalibration">
               <Pin Id="BZ4HKAWlxujP565J93Ep2Z" Name="Calibration" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Observable" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -2450,7 +2451,6 @@
                 </p:TypeAnnotation>
               </Pin>
             </Patch>
-            <Link Id="JgkVSin6zQ0OXM8olKv3Er" Ids="FdAKiwrxeM9MpjtJzlp7mK,BZ4HKAWlxujP565J93Ep2Z" IsHidden="true" />
           </Patch>
         </Node>
         <!--
@@ -2463,7 +2463,7 @@
             <Choice Kind="ForwardDefinition" Name="Forward" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
-          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
             <Choice Kind="TypeFlag" Name="ImuSample" />
           </p:TypeAnnotation>
           <Patch Id="GD2a1YGFS3yLrAWanQkBef">
@@ -2481,7 +2481,7 @@
                 <p:HideCategory p:Type="Boolean">false</p:HideCategory>
                 <Patch Id="SuUsSQecATqMDdAVITbrxS">
                   <Node Bounds="322,384,114,26" AutoConnect="true" Id="C9PnxQ5sFV1NvMsW6cFXiV">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="OperationNode" Name="AccelerometerSample" />
                       <FullNameCategoryReference ID="Microsoft.Azure.Kinect.Sensor.ImuSample" />
                     </p:NodeReference>
@@ -2491,7 +2491,7 @@
                   </Node>
                   <Link Id="Moye4JbDbaXPj5g3pJxW5Z" Ids="UfDvuUyA4TnNPJjRf5svZb,FpRK4EeYvtAMYg6I61dVUW" />
                   <Node Bounds="444,433,16,19" Id="JFZQs2oB1PcNRoFouPnzKu">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToVector3" />
                       <CategoryReference Kind="Category" Name="AzureKinect" NeedsToBeDirectParent="true">
@@ -2522,7 +2522,7 @@
                 <p:HideCategory p:Type="Boolean">false</p:HideCategory>
                 <Patch Id="Q7ng2mQSyeIMHZKhotSwZH">
                   <Node Bounds="629,393,128,26" AutoConnect="true" Id="R1g3ETiSpxTMlxdrhDDxWo">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="OperationNode" Name="SetAccelerometerSample" />
                       <FullNameCategoryReference ID="Microsoft.Azure.Kinect.Sensor.ImuSample" />
                     </p:NodeReference>
@@ -2532,7 +2532,7 @@
                   </Node>
                   <Link Id="RHHRoZJFps4K9hG1t2ORKt" Ids="RFeUaaOvGzzLXG3YZS2J72,Q5U7Qx18BKHNFvKarisKt4" />
                   <Node Bounds="748,347,16,19" Id="GOkKOYnTju6LVxYYdqWHDG">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromVector3" />
                     </p:NodeReference>
@@ -2560,7 +2560,7 @@
                 <p:HideCategory p:Type="Boolean">false</p:HideCategory>
                 <Patch Id="J2bQntGi06BL9PK6WoCEnl">
                   <Node Bounds="357,635,10,10" AutoConnect="true" Id="FiUA2iN8FlJP98Bn8Z0KzG">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="OperationNode" Name="GyroSample" />
                       <FullNameCategoryReference ID="Microsoft.Azure.Kinect.Sensor.ImuSample" />
                     </p:NodeReference>
@@ -2570,7 +2570,7 @@
                   </Node>
                   <Link Id="NfVD73eJVYnQVXWYMtG1ad" Ids="J2tMh86JL1tOQ7zvbWqYYj,J69GWgCNUkHMTPPQ7ByIjr" />
                   <Node Bounds="424,683,63,19" Id="Lv1pQg6VJj4NvepgMZmjwX">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToVector3" />
                       <CategoryReference Kind="Category" Name="AzureKinect" NeedsToBeDirectParent="true">
@@ -2601,7 +2601,7 @@
                 <p:HideCategory p:Type="Boolean">false</p:HideCategory>
                 <Patch Id="O3uoMegO834NoVXlEFItJj">
                   <Node Bounds="623,701,84,26" AutoConnect="true" Id="OiN7YFGyQqyNVV9d1Mbq2U">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="OperationNode" Name="SetGyroSample" />
                       <FullNameCategoryReference ID="Microsoft.Azure.Kinect.Sensor.ImuSample" />
                     </p:NodeReference>
@@ -2611,7 +2611,7 @@
                   </Node>
                   <Link Id="B6HYvYhFQeaOU86mo8cL3H" Ids="EfScyVuK8gsOxjYT1cwrGA,H1b4DdpwI5uPVltMXBc7dc" />
                   <Node Bounds="702,659,75,19" Id="D9PmkaJqMU6NV2MLuiclJk">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromVector3" />
                     </p:NodeReference>
@@ -2632,13 +2632,13 @@
 
 -->
               <Node Name="Split" Bounds="209,856,1009,218" Id="QZnJIYZGMuRPMMSvz1DVAk">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
                 <p:HideCategory p:Type="Boolean">false</p:HideCategory>
                 <Patch Id="EOecZeiE0MRLMlwbaG8ymx">
                   <Node Bounds="222,913,114,26" Id="Guc58PNJODwOoyKWnxvW4O">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AccelerometerSample" />
                       <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -2656,7 +2656,7 @@
                   <Pin Id="MBkOjXfd9BoO2x7sZTxWCP" Name="Accelerometer Sample" Kind="OutputPin" Bounds="625,991" />
                   <Link Id="TmVXqbnJYdePlRKN9npJAI" Ids="KfaLFuBV9MHN5mhpAbYMR5,MBkOjXfd9BoO2x7sZTxWCP" IsHidden="true" />
                   <Node Bounds="390,915,132,26" Id="TaDWJL31DrjOEwNX9XI1xL">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AccelerometerTimestamp" />
                       <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -2670,7 +2670,7 @@
                   <Pin Id="DwluizKPcniQNdrYJRJ1M0" Name="Accelerometer Timestamp" Kind="OutputPin" Bounds="812,983" />
                   <Link Id="RQduysq9RNiLErqjDAClmK" Ids="DqJxS2NnZhGMfPmYMmma9T,DwluizKPcniQNdrYJRJ1M0" IsHidden="true" />
                   <Node Bounds="675,913,70,26" Id="LyWLvMgCPNyMBGoRTlqL3t">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GyroSample" />
                       <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -2687,7 +2687,7 @@
                   <Link Id="OYlFHht3E5sNwrSBFsMFRg" Ids="Ri5hx7fNS6HK90Kn8y9CjJ,HSTntR9TQhyPQdDpGdeu1E" IsHidden="true" />
                   <Link Id="L7KtSWawyElPO1rroUdbgO" Ids="I3EjUNKgGboOV9qeFqwMbp,BXNqLdssPGQO8Rjh4ixlul" />
                   <Node Bounds="834,915,56,26" Id="DGo1bNiAQulP3XAijBbITn">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GyroTimestamp" />
                       <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -2700,7 +2700,7 @@
                   <Pin Id="IEPX6x8H4YwOhqQr34Dex2" Name="Gyro Timestamp" Kind="OutputPin" Bounds="917,969" />
                   <Link Id="Ktu34VzowHKNIAXFZ9VgXq" Ids="MGD1pMPFTUbMQj23yZ2YZa,IEPX6x8H4YwOhqQr34Dex2" IsHidden="true" />
                   <Node Bounds="519,971" Id="LUZn5d9fOdTQLwtNMrMwZF">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                     </p:NodeReference>
@@ -2709,7 +2709,7 @@
                   </Node>
                   <Link Id="JhNZcUtNarKQE19A7MxKdc" Ids="RgQLobe6wqxPeutV2GeoyI,SQmnCI5iKCdOEniHdcEKL6" />
                   <Node Bounds="521,1014" Id="VHBGJm5WqeDMI9XwdZRJWW">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                     </p:NodeReference>
@@ -2718,7 +2718,7 @@
                   </Node>
                   <Link Id="R6HqEWJGn11NhZjithGvM8" Ids="T2MRP1x0PQdLeI6CjtaMsQ,DqJxS2NnZhGMfPmYMmma9T" />
                   <Node Bounds="917,966,77,26" Id="IpZqhC88uXhMYwHyNG4Scj">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                     </p:NodeReference>
@@ -2726,7 +2726,7 @@
                     <Pin Id="ISfvBoHwogzMXwKUPdpliC" Name="Total Seconds" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="919,1009,62,19" Id="TAriREJDNw0OQ3GuzbEvsX">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                     </p:NodeReference>
@@ -2737,7 +2737,7 @@
                   <Link Id="VOSaa8Mdu4tQWMIOhWhpGQ" Ids="IwxNSQJ5GvILe4YJgcRSWf,VXP3WLERD5aNcipGf0ak1d" />
                   <Link Id="U1gl78QoSSfLc2zIas8zWP" Ids="DQlSob8zjIIOzuQj0Vz2CS,MGD1pMPFTUbMQj23yZ2YZa" />
                   <Node Bounds="1063,929,56,26" Id="URcyZAgFaX4OWH5J9HJya1">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Temperature" />
                       <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -2776,7 +2776,7 @@
           <p:HideCategory p:Type="Boolean">false</p:HideCategory>
           <Patch Id="Hv4aC32Zqq5NSHmtvjxJba">
             <Node Bounds="575,516,99,26" AutoConnect="true" Id="AiczOS2PQWKLqcfcYYRH9G">
-              <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+              <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                 <Choice Kind="OperationNode" Name="AsVLImage" />
                 <FullNameCategoryReference ID="VL.Devices.AzureKinect.KinectImageExtensions" />
               </p:NodeReference>
@@ -2808,12 +2808,12 @@
 
 -->
               <Node Name="GetFOV (Internal)" Bounds="742,264,285,398" Id="UVh2rQ4GZkbQKJcKm68Ppr">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
                 <Patch Id="LArZx3njcS8LoXRlVrZTSE">
                   <Node Bounds="754,310,83,26" Id="AUIJPG9I0mzOyG73SCRk0h">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="CameraCalibration" />
                       <Choice Kind="OperationCallFlag" Name="MetricRadius" />
@@ -2823,7 +2823,7 @@
                     <Pin Id="H7KMpnm76KRL9WIVX9BtEG" Name="Metric Radius" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="754,361,90,26" Id="KasUXyLIO2IQLN34Fme7nA">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="CameraCalibration" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionWidth" />
@@ -2838,7 +2838,7 @@
                   <Link Id="LBYwsA0nRc3LDV0BlKKuYX" Ids="Fk3A2ZCow26P0LolaDS2lT,SqeuYL2NulALOfVAiGbKX9" IsHidden="true" />
                   <Link Id="DXSd7ufqf0MLnVZ6NbOhx1" Ids="KVRQFkgva8TONUP8mZWLDt,DpaKU0ad1BFOGJQAsZu4rJ" />
                   <Node Bounds="754,410,94,26" Id="Tkmc76ILOrEMQyjKOuLywT">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionHeight" />
                     </p:NodeReference>
@@ -2849,7 +2849,7 @@
                   <Link Id="VxQ68Hw5dSYM38MRnNdhAN" Ids="H7KMpnm76KRL9WIVX9BtEG,DQRnPz8pH9RLhFlwXFgbvI" />
                   <Link Id="OYvDR1PZCQTL8vhNcWs7aO" Ids="SqeuYL2NulALOfVAiGbKX9,Lau1KETpaWgLdtwYvbh3gA" />
                   <Node Bounds="784,561,92,19" Id="HJD1kSQx5GwN7kKN9mNoBP">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="RadiansToCycles" />
                     </p:NodeReference>
@@ -2857,7 +2857,7 @@
                     <Pin Id="Rgu5cejD8jBPg2W37RXkJH" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="937,488,25,19" Id="AfVQkaQRP09LojKGqiW68U">
-                    <p:NodeReference LastCategoryFullName="Primitive.Float32" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Float32" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="/" />
                       <CategoryReference Kind="Float32Type" Name="Float32" NeedsToBeDirectParent="true" />
@@ -2867,7 +2867,7 @@
                     <Pin Id="Cpx24d6Gsb2NdROE4KuT2l" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="915,518,25,19" Id="Urlw8ZqMw7YOlWkCVTwZiN">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="*" />
                     </p:NodeReference>
@@ -2876,7 +2876,7 @@
                     <Pin Id="BXAODn2z7ThMtpDv2wibYb" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="923,566,92,19" Id="LHIGsWhZF8nOpHNDkmS85o">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="RadiansToCycles" />
                     </p:NodeReference>
@@ -2886,7 +2886,7 @@
                   <Link Id="D17zYgdGSYPNkoQIVlUqrw" Ids="Cpx24d6Gsb2NdROE4KuT2l,SUbuIkqCJx6M4nvsKspizZ" />
                   <Link Id="KiQUtM2H0KkQSmKMsh8kPV" Ids="BXAODn2z7ThMtpDv2wibYb,SSKx5MyADQAOTyDHT9Cyzd" />
                   <Node Bounds="879,599,46,19" Id="A7xPCmF0BzBLnU2gEgTnLm">
-                    <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Vector2Type" Name="Vector2" />
                       <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -2905,13 +2905,13 @@
                   <Pin Id="IUKMTl4WFysQENQ5y1Fjrc" Name="Output" Kind="OutputPin" Bounds="1100,1229" />
                   <Link Id="R7xTAD0tX1kN8CA52Vc6YT" Ids="FahSBGifnYyO650RjuoZ4a,IUKMTl4WFysQENQ5y1Fjrc" IsHidden="true" />
                   <Node Bounds="948,451,35,19" Id="Kdg1SVuN2XIMIuJ2CucwWi">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Max" />
                     </p:NodeReference>
                     <Pin Id="I7alzAqSfapNNPxLnINnxf" Name="Input" Kind="InputPin" />
                     <Pin Id="QMgXVQUUgBqLXtwn6yRW3d" Name="Input 2" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Integer32" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -2923,7 +2923,7 @@
               <ControlPoint Id="TvzzB7Ky7UZONIWQivnVvz" Bounds="226,814" />
               <ControlPoint Id="FnxaNHHGNF9MOkx3KecgQG" Bounds="506,814" />
               <Node Bounds="127,266,82,26" Id="USRBhR3GusELN9tRNxDQTq">
-                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCalibration" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -2933,7 +2933,7 @@
                 <Pin Id="TdMmdy5LIQJPkuscEyuN6D" Name="Calibration" Kind="OutputPin" />
               </Node>
               <Node Bounds="125,320,65,19" Id="MDb5bHlivYhPtgy0fwa0lj">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                 </p:NodeReference>
@@ -2943,7 +2943,7 @@
                 <Pin Id="LH8nuXeX0ZaLY5k44QRZeb" Name="On Data" Kind="OutputPin" />
               </Node>
               <Node Bounds="125,367,58,26" Id="LBAYohwQlWHOX9LoBbUyAh">
-                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Nullable" />
                   <Choice Kind="OperationCallFlag" Name="HasValue" />
@@ -2953,7 +2953,7 @@
                 <Pin Id="KWMpiDToR7vPKSlAyvCD9g" Name="Has Value" Kind="OutputPin" />
               </Node>
               <Node Bounds="40,436,624,334" Id="NmG15J7zs9cMOv9BxZLTvn">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -2973,7 +2973,7 @@
                   <Patch Id="B3v3bTMO7VSPPZw9BwunXY" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="GjEPXzx0ZfON16h6j4nx2A" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="125,460,46,26" Id="QwBC6lD7RLmOsrfmNOV0Wm">
-                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Nullable" />
                       <Choice Kind="OperationCallFlag" Name="Value" />
@@ -2983,7 +2983,7 @@
                     <Pin Id="N9e9hlX0j0zLkUkja7hHzo" Name="Value" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="583,520,69,26" Id="KPDW32zwAz5MSTa8Ki9RDu">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Calibration" />
                       <Choice Kind="OperationCallFlag" Name="DepthMode" />
@@ -2993,7 +2993,7 @@
                     <Pin Id="KLUpcp60fmyLLwSBGhq6rO" Name="Depth Mode" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="325,512,89,26" Id="RQHUn2J0373NG4J0HjkZXe">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Calibration" />
                       <Choice Kind="OperationCallFlag" Name="ColorResolution" />
@@ -3003,7 +3003,7 @@
                     <Pin Id="RdZMOobxZuZLznRhMkBjAf" Name="Color Resolution" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="246,560,50,19" Id="QAY0GGqCKT2Mc3XoVyTfeq">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.FOV" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.FOV" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetFOV" />
                     </p:NodeReference>
@@ -3011,7 +3011,7 @@
                     <Pin Id="R6KLBxwQ4ukMnqpLz1kJIu" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="169,511,125,26" Id="OpS8m77MkBHQaYjfe3Basj">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ColorCameraCalibration" />
                     </p:NodeReference>
@@ -3020,7 +3020,7 @@
                     <Pin Id="BPr7GdNJ8vGLi2LVAU3rLC" Name="Color Camera Calibration" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="521,570,50,19" Id="FYt7micllBXOwAPAzZSWQC">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.FOV" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.FOV" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetFOV" />
                     </p:NodeReference>
@@ -3028,7 +3028,7 @@
                     <Pin Id="EbRr8sE97hGPwofS33J8ZI" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="435,518,128,26" Id="BxeGNQjsW1LOHPTezajCjl">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="DepthCameraCalibration" />
                     </p:NodeReference>
@@ -3037,7 +3037,7 @@
                     <Pin Id="LBNc1lH3IDOQanwUhqKRWe" Name="Depth Camera Calibration" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="57,540,83,26" Id="RkkZtbpOq6WN1yapHCds4c">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="CameraCalibration" />
                       <Choice Kind="OperationCallFlag" Name="Extrinsics" />
@@ -3047,7 +3047,7 @@
                     <Pin Id="NW0HDbg93iwPspn14xmwAf" Name="Extrinsics" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="52,578,54,26" Id="EW8EojwLeraPYfd4mEJv7Z">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Extrinsics" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Extrinsics" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Extrinsics" />
                       <Choice Kind="OperationCallFlag" Name="Rotation" />
@@ -3057,7 +3057,7 @@
                     <Pin Id="K3ErpuGhlihQBFWQnZFUHl" Name="Rotation" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="146,576,67,26" Id="VqY8q8YzdgkLK2oNPDydwf">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Extrinsics" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Extrinsics" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Translation" />
                       <CategoryReference Kind="AssemblyCategory" Name="Extrinsics" NeedsToBeDirectParent="true" />
@@ -3067,7 +3067,7 @@
                     <Pin Id="By4FZBQLcSvM2Is5JrVhU7" Name="Translation" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="72,712,305,26" Id="OmWIbEUOkGtMVmxRQtcrDc">
-                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Matrix" />
                       <Choice Kind="OperationCallFlag" Name="Matrix (Join)" />
@@ -3088,14 +3088,14 @@
                     <Pin Id="M671MWSdQlcLVymPfWywJt" Name="M42" Kind="InputPin" />
                     <Pin Id="JBdOODDfVnxOaw62R6m9GA" Name="M43" Kind="InputPin" />
                     <Pin Id="FiY3Z0o7gUBLWO8V70y77o" Name="M44" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="Prtmj6cFxamLIyhNpFBVTr" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="97,631" Id="GoReSPCUwOKN77CsbPGeIk">
-                    <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Decons" />
                       <CategoryReference Kind="ArrayType" Name="MutableArray" NeedsToBeDirectParent="true" />
@@ -3112,7 +3112,7 @@
                     <Pin Id="SmZLLgyrTIFMARbr08VWrd" Name="Result 9" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="308,619" Id="IU4kXDRsCh3MtP8zoPc7ft">
-                    <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Decons" />
                       <CategoryReference Kind="ArrayType" Name="MutableArray" NeedsToBeDirectParent="true" />
@@ -3123,20 +3123,20 @@
                     <Pin Id="RXKbSX0IzeTOrCCRURmBET" Name="Result 3" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="300,668,25,19" Id="QLlF1OoM9yXQOV3o2cGLQz">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="*" />
                     </p:NodeReference>
                     <Pin Id="MFXp1ymfyS9OiRdfUtn3bX" Name="Input" Kind="InputPin" />
                     <Pin Id="BFDwWfe8L3pPC1moFjS5V2" Name="Input 2" Kind="InputPin" DefaultValue="0.001">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="T9Z4UBvQY8XMaOlOowIuAV" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="R9iG2fRwBpoOMChNuxuG3R" Comment="" Bounds="386,642,35,15" ShowValueBox="true" isIOBox="true" Value="0.001">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                     <p:ValueBoxSettings>
@@ -3144,7 +3144,7 @@
                     </p:ValueBoxSettings>
                   </Pad>
                   <Node Bounds="333,671" Id="FE1gdZIbddFQNgJHF2Z8Pq">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="*" />
                     </p:NodeReference>
@@ -3153,7 +3153,7 @@
                     <Pin Id="Czi0t61a3H4NgEZDgS5WCg" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="364,670,25,19" Id="GhdyPiZTDsZOsqDZO9kKc3">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="*" />
                     </p:NodeReference>
@@ -3252,15 +3252,15 @@
 
 -->
       <Node Name="InfraredImage" Bounds="120,466" Id="R3vLYNaep14LTg6OMqOYwe">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="MKb3EPYJ04SMAkhhUWhMWI">
           <Canvas Id="NcQfW1faMnpOs6JLvfI8El" CanvasType="Group">
             <ControlPoint Id="UfWyvJldMQrMse26sxWWs9" Bounds="378,215" />
             <ControlPoint Id="LVjnvJZcusSNjK6oUEezzF" Bounds="378,371" />
-            <Node Bounds="377,309,88,19" Id="N2nZCjlBMl1Ogu0KVCDldv">
-              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+            <Node Bounds="376,309,88,19" Id="N2nZCjlBMl1Ogu0KVCDldv">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
               </p:NodeReference>
@@ -3272,7 +3272,7 @@
               <Pin Id="DiNJiBJdxYxLbEnGAQ5Psd" Name="Drop Count" Kind="OutputPin" />
             </Node>
             <Node Bounds="376,247,69,19" Id="ClKHxBDWXkVLKn2CdniSaw">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="InfraredImage (Reactive)" />
               </p:NodeReference>
@@ -3338,14 +3338,14 @@
 
 -->
       <Node Name="IMUData" Bounds="400,508" Id="T85CkLaO9jMLgcUcHueTaI">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="KuXWlGOI3BVMWNJjEw9wJ8">
           <Canvas Id="KmOURlQpoR2LftdLy8LLIc" CanvasType="Group">
             <ControlPoint Id="ErGZn4EO7aCONvXDQrXuDA" Bounds="388,250" />
             <Node Bounds="391,330,65,19" Id="Al3SM0xDA5DQRI0alh6svn">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -3355,7 +3355,7 @@
               <Pin Id="N1RSQZX6JCiQM0pP8VD76w" Name="On Data" Kind="OutputPin" />
             </Node>
             <Node Bounds="348,365,65,19" Id="Qe45ZI9OJpdMA9Sga6mtBD">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
               </p:NodeReference>
@@ -3364,7 +3364,7 @@
               <Pin Id="DZgvAell6OMPtbh3NkuDJh" Name="Not Assigned" Kind="OutputPin" />
             </Node>
             <Node Bounds="387,281,54,19" Id="CG7xDL58luCQYvSqkf24Gt">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="IMUData (Reactive)" />
               </p:NodeReference>
@@ -3372,7 +3372,7 @@
               <Pin Id="Myclw0Xq47FOJMyVgvNgeZ" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="390,406,106,80" Id="RD0Ku7iUp98NdilLhEgWdL">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -3390,7 +3390,7 @@
                 <Patch Id="Uu4r5ef4hnhLLpax9PRVwq" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="D6wuPwHSt1kLq7JitwL9fn" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="402,437,65,19" Id="VK45FXxNiyeMEvMKnkS9LI">
-                  <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                  <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
                     <CategoryReference Kind="ClassType" Name="ImuSample" NeedsToBeDirectParent="true" />
@@ -3460,7 +3460,7 @@
 
 -->
         <Node Name="DeviceTransformationInternal" Bounds="337,360" Id="ATSQpaGZkVMLLlZ4yGXRVv">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="BINQJo9ymuSO85AkNvvj9W">
@@ -3474,7 +3474,7 @@
               <Pad Id="ItUFJYpyCi9LA1TJRT9C9K" SlotId="I560rwXygVZPo9YDwZeeYL" Bounds="545,1162" />
               <Pad Id="G0C7O055wJOOTDLZiY9e9F" SlotId="I560rwXygVZPo9YDwZeeYL" Bounds="546,252" />
               <Node Bounds="397,1169,45,19" Id="HCjWGBkldaWP1gk00lwylN">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch" />
                   <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -3485,7 +3485,7 @@
                 <Pin Id="JbrBgGc0VU5PQA8Nuhbmk1" Name="Output" Kind="OutputPin" />
               </Node>
               <Pad Id="GhrSjh0nihXNCkZJo5gpIJ" Bounds="250,1115,35,35" ShowValueBox="true" isIOBox="true" Value="False">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -3495,7 +3495,7 @@
               <Pad Id="OBZcCojKazrLe1ipZ0ZlGV" Comment="Velocity" Bounds="544,1241,70,43" ShowValueBox="true" isIOBox="true" />
               <ControlPoint Id="LsT16vRJYEFM04S6I4bJey" Bounds="393,1389" />
               <Node Bounds="433,1310,46,19" Id="Kybo7LCN4BWQEJ9NbmQ2ms">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3506,7 +3506,7 @@
                 <Pin Id="FK2ZI5dPycEL99EGPPZCc9" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="434,1266,46,19" Id="K47H3WX9lTWOgwTrxPIJLX">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Split)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3517,7 +3517,7 @@
                 <Pin Id="HdnYAtmLX74N4gbeaWNxUh" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="316,1165,45,19" Id="LU6eQb9uzauMFD7Qh6E58J">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch" />
                   <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -3535,7 +3535,7 @@
               <Pad Id="Cw8kHqRIW4SLjTaxLs6MWK" SlotId="HkeYc5q4UVlOBJ2yD4b3OG" Bounds="1354,1227" />
               <Pad Id="JPGqk2YDPu4QbvYhg70J99" SlotId="HkeYc5q4UVlOBJ2yD4b3OG" Bounds="1358,951" />
               <Node Bounds="1337,1175,45,19" Id="VEJw8Kom9A9QTBzpQ2lSA7">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch" />
                   <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -3547,7 +3547,7 @@
               </Node>
               <Pad Id="TVqgFzsGytuP3S9qFxSjId" Comment="Gyro" Bounds="1346,1284,35,43" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="390,430,114,26" Id="MYKrn166tZbLWpQnfel8MV">
-                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ImuSample" />
                   <Choice Kind="OperationCallFlag" Name="AccelerometerSample" />
@@ -3558,7 +3558,7 @@
               </Node>
               <Pad Id="NyDiSKpdKRbOywJ8t1slmE" Comment="Accelerometer Sample" Bounds="385,476,149,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="1108,427,114,26" Id="G8kibWlAP8zMe1L5IbIv7F">
-                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ImuSample" />
                   <Choice Kind="OperationCallFlag" Name="GyroSample" />
@@ -3568,7 +3568,7 @@
                 <Pin Id="BgQoUtlC8TXMvTfThm7o12" Name="Gyro Sample" Kind="OutputPin" />
               </Node>
               <Node Bounds="692,434,132,26" Id="E8jth2fGVZqLtraNAx8JUW">
-                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.ImuSample" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ImuSample" />
                   <Choice Kind="OperationCallFlag" Name="AccelerometerTimestamp" />
@@ -3578,7 +3578,7 @@
                 <Pin Id="OZp6HEz6i2INaz3Sbilwps" Name="Accelerometer Timestamp" Kind="OutputPin" />
               </Node>
               <Node Bounds="1564,418,88,26" Id="FV5h0UDuipVNJqUakMPRud">
-                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ImuSample" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GyroTimestamp" />
                 </p:NodeReference>
@@ -3588,7 +3588,7 @@
               </Node>
               <Pad Id="Daun6L8egqyOlY8shETDaQ" Comment="Gyro Sample" Bounds="1165,478,149,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="719,539,25,19" Id="HCPrQFII7mOP4Rt4BRruP5">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -3598,7 +3598,7 @@
               </Node>
               <Pad Id="KnKR2LqIjPbOzakiSMlDsb" Comment="" Bounds="722,575,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="1582,549,25,19" Id="UoJ6AAV4ZFcOoOlKXWWLJV">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -3608,7 +3608,7 @@
               </Node>
               <Pad Id="HHy5CYX6RzKNNZmGreLx5W" Comment="" Bounds="1591,586,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="365,524,44,19" Id="Hjc4NVNPvKkPvlENyfPZph">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                   <Choice Kind="OperationCallFlag" Name="X" />
@@ -3618,7 +3618,7 @@
                 <Pin Id="GAWhubOUy4WLOk8reUsWEN" Name="X" Kind="OutputPin" />
               </Node>
               <Node Bounds="430,524,44,19" Id="F4TrxMoY4vDPpZPZQIDUYz">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Y" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3628,7 +3628,7 @@
                 <Pin Id="HWxF15O5QukLxUVGfpZRk2" Name="Y" Kind="OutputPin" />
               </Node>
               <Node Bounds="493,524,44,19" Id="Bv6tIkavPoyMSJxH8xjBoe">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Z" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3638,7 +3638,7 @@
                 <Pin Id="KW1P3aptcbrOuW4J6MwGEY" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="422,560,46,19" Id="P16d64KxVxCM7v1GhUYO7k">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3649,7 +3649,7 @@
                 <Pin Id="EIbkPEN2wNDMAjlQUg3AFk" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="411,654,25,19" Id="H2moPY0fm4QLIYXRcxNoKr">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3658,21 +3658,21 @@
                 <Pin Id="BxHLqJLYL69LIstWYm9sXW" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="431,627,45,19" Id="BLoA910ySK8OXakLzSIgYQ">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                 </p:NodeReference>
                 <Pin Id="El1xavqo91EMsNa8VpUfOu" Name="Input" Kind="InputPin" />
                 <Pin Id="VXYZ5wiiFWWM1ugXsSSRqV" Name="Scalar" Kind="InputPin" />
-                <Pin Id="T6Y3zn8Ez75Ld4kSy8icwx" Name="Output" Kind="OutputPin" />
                 <Pin Id="Py4IMfgwLOXOcDe3iDB4WT" Name="Scalar 2" Kind="InputPin" DefaultValue="0.5">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
+                <Pin Id="T6Y3zn8Ez75Ld4kSy8icwx" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="702,591,62,19" Id="NECKXqYSiJiQBvxhS7ba71">
-                <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                 </p:NodeReference>
@@ -3680,7 +3680,7 @@
                 <Pin Id="V3JgcTe30C4Lfl0HMRCJin" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="818,480,77,26" Id="S2tg8InGV8xQIgpVn4X1ly">
-                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                 </p:NodeReference>
@@ -3688,7 +3688,7 @@
                 <Pin Id="Ghb2p39UCoBMF6BqNl9gXH" Name="Total Seconds" Kind="OutputPin" />
               </Node>
               <Node Bounds="337,762,25,19" Id="IA5TE7L6xjQMhAOwFn7sOf">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3697,21 +3697,21 @@
                 <Pin Id="C51b3SmyV2MOs4XgGuImmY" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="358,731,45,19" Id="CAPjvooGp6NLxckI1aRyfP">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                 </p:NodeReference>
                 <Pin Id="SOqS1qGjFDwO6vueKkA2H6" Name="Input" Kind="InputPin" />
                 <Pin Id="Ohc48KGREPFMf1No6NSm0n" Name="Scalar" Kind="InputPin" />
-                <Pin Id="GKlDOv60mOsLoQvkDjI3Uv" Name="Output" Kind="OutputPin" />
                 <Pin Id="O9eEwnFg91HLvtmfVm1QjO" Name="Scalar 2" Kind="InputPin" DefaultValue="0.5">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
+                <Pin Id="GKlDOv60mOsLoQvkDjI3Uv" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1157,507,44,19" Id="NwFTUexHPOXLqAED0UyNaN">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" />
                   <Choice Kind="OperationCallFlag" Name="X" />
@@ -3721,7 +3721,7 @@
                 <Pin Id="UY3Pd8FM4RgOqGJ9cli0fH" Name="X" Kind="OutputPin" />
               </Node>
               <Node Bounds="1222,507,44,19" Id="RSRGpWM5QfLLndtmgUeqZO">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Y" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3731,7 +3731,7 @@
                 <Pin Id="I6VbVwZnmKyOcwhFWBhO5e" Name="Y" Kind="OutputPin" />
               </Node>
               <Node Bounds="1285,507,44,19" Id="FpPMvc6DngdOFK3th14lWo">
-                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastSymbolSource="System.Numerics.Vectors.dll">
+                <p:NodeReference LastCategoryFullName="System.Numerics.Vector3" LastDependency="System.Numerics.Vectors.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Z" />
                   <CategoryReference Kind="AssemblyCategory" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3741,7 +3741,7 @@
                 <Pin Id="DmEdTpYD7YILcsEcR423iz" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="1198,550,46,19" Id="J99yz5Ym0KZMuhQRYRuTw8">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3752,7 +3752,7 @@
                 <Pin Id="GYpKa8o1VQ8OO7eLkktBh1" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="871,703,25,19" Id="KP57zreH5sxMbmRWZmYHKJ">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                   <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -3762,7 +3762,7 @@
                 <Pin Id="UbbXUx1QKDwLOvHwLOkNqB" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="932,621,45,19" Id="J22zFa6MSmSLqfWRTilGwo">
-                <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Rotate" />
                   <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -3774,7 +3774,7 @@
                 <Pin Id="VFIneYu46BHQDTfNxujXwu" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="873,653,64,19" Id="LAX9Cs4O4w2MrnVd6NXH0m">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Transform" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3784,7 +3784,7 @@
                 <Pin Id="JuVrjZiAfCKL0UWPFy7J2K" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Pad Id="TlaVHWIV7g9LvEfDqoC43g" Comment="" Bounds="872,604,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0, 9.812">
-                <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Vector3" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -3792,7 +3792,7 @@
                 </p:ValueBoxSettings>
               </Pad>
               <Node Bounds="1649,469,77,26" Id="KTvXEB0zxCBQPe0c2S5Bqv">
-                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                 </p:NodeReference>
@@ -3802,7 +3802,7 @@
               <Pad Id="Fi1XARxY78jNwYEBiqFzTF" Comment="Total Seconds" Bounds="1676,531,41,15" ShowValueBox="true" isIOBox="true" />
               <Pad Id="KINBugO1NHpNyv7V2VJwq6" Comment="Total Seconds" Bounds="844,533,41,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="1384,934,25,19" Id="VsV1bp0IrKXOlSP8y0bZaE">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3811,21 +3811,21 @@
                 <Pin Id="IdyvP2dOHJiN0czcNkiHKR" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1379,977,45,19" Id="BdINaPtgdgfL6F8dwn9dFI">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                 </p:NodeReference>
                 <Pin Id="BJfw8T2rAv8OgjGVb7ZBSS" Name="Input" Kind="InputPin" />
                 <Pin Id="TCUW5j20rxWNYLSlbW2JEF" Name="Scalar" Kind="InputPin" />
-                <Pin Id="BtDurrNJ6nKLoVzUF5bfFq" Name="Output" Kind="OutputPin" />
                 <Pin Id="UkRoLkIc6CBLEoXiYOHixi" Name="Scalar 2" Kind="InputPin" DefaultValue="0.5">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
+                <Pin Id="BtDurrNJ6nKLoVzUF5bfFq" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1575,600,62,19" Id="HHlEL5VRWvqPocOBPTR7UJ">
-                <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                 </p:NodeReference>
@@ -3833,7 +3833,7 @@
                 <Pin Id="SQNb2k3As4cNU2zE0aqFQy" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1359,1018,25,19" Id="Ol4qbGqRlv5NM99Yjxc08r">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3842,7 +3842,7 @@
                 <Pin Id="FlHCx3G0kXLL3ooXZtYcZZ" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1382,691,46,19" Id="NQV8xyqDOfFN1Y7akAIisX">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Split)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3853,7 +3853,7 @@
                 <Pin Id="JLB8NwXKv6cOkQNXLZgzul" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="1382,808,46,19" Id="NoCulYX1MpfLzzNnxcCyJD">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3864,7 +3864,7 @@
                 <Pin Id="RiA9f5bOoZ9Pp7lHrjSUWk" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1382,723,92,19" Id="IikCiujkH3MNTjSGsuRl9k">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="RadiansToCycles" />
                 </p:NodeReference>
@@ -3872,7 +3872,7 @@
                 <Pin Id="NjuYYKujPnSPL7qKCtTcUw" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1412,753,92,19" Id="VsrRFncDaeUPesRZhYKc2O">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="RadiansToCycles" />
                 </p:NodeReference>
@@ -3880,7 +3880,7 @@
                 <Pin Id="AjXAsS2cBQkMJoKzLrVS8T" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1442,783,92,19" Id="GuLYB20vcOoNuObXNdYulf">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="RadiansToCycles" />
                 </p:NodeReference>
@@ -3889,7 +3889,7 @@
               </Node>
               <Pad Id="HM4BPn2FfuPLiQcRHvFW6L" Comment="" Bounds="917,691,35,43" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="619,524,48,19" Id="HHgdr5Ig3HXM6UmzSWDii2">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Length" />
                 </p:NodeReference>
@@ -3897,20 +3897,20 @@
                 <Pin Id="IFVhTrOXdcLOW8NlpF7pmt" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="619,557,25,19" Id="Tab8K58LyPRPWdidBTk21p">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
                 <Pin Id="EHCIT6WzXv8LmakdGfAtNP" Name="Input" Kind="InputPin" />
                 <Pin Id="OjX7CduXytRMVyYn6Ibcxj" Name="Input 2" Kind="InputPin" DefaultValue="9.812">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="JtD3gI1tcGAMTrCNKg9oFm" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="619,585,34,19" Id="EOzNTLt2fb8NCycrvk8jtO">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Abs" />
                 </p:NodeReference>
@@ -3919,36 +3919,36 @@
               </Node>
               <Pad Id="PWvIJmv41cCNKcjX0l81qE" Comment="" Bounds="620,618,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="632,681,85,19" Id="DR2mYrRyOQKPavsBpR0qjR">
-                <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="MapClamp" />
                 </p:NodeReference>
                 <Pin Id="JNIfyR02avILUNq6BnAaDV" Name="Input" Kind="InputPin" />
                 <Pin Id="LR04kRut7tbNFguSp9svZx" Name="Input Minimum" Kind="InputPin" DefaultValue="0.09">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="UJqtAdlqm5ELxAIHrGM8hD" Name="Input Maximum" Kind="InputPin" DefaultValue="0.05">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="H3pb6XqV4JpMwhGlAZNTWx" Name="Output Minimum" Kind="InputPin" />
                 <Pin Id="H76rR3RsGKzM708a2EtMYv" Name="Output Maximum" Kind="InputPin" DefaultValue="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="RGV1XZOCLE1MAv010LizwI" Name="Output" Kind="OutputPin" />
               </Node>
               <Pad Id="L9MhhoviDvzOvMhDxxKtd0" Comment="Output Minimum" Bounds="732,640,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="412,686,45,19" Id="H9KUwlQagh4NV6yenud8dC">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -3959,7 +3959,7 @@
               </Node>
               <Pad Id="Rd7bfjLnXKuOsHpeRSW6c4" Comment="" Bounds="702,724,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="505,603,25,19" Id="C7AyaCJLFXwOJtacqtax3Q">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3968,7 +3968,7 @@
                 <Pin Id="QIdYt5qqUSyPLRncDmNUkE" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1137,939,46,19" Id="KH2HN8oFy5VLjUTwAnZCUA">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Split)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3979,7 +3979,7 @@
                 <Pin Id="GDqF3dMZl6JPTMdSvTTbhx" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="1139,1068,46,19" Id="FiDtz6KxKhKO2LRSdhM3CN">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -3990,7 +3990,7 @@
                 <Pin Id="MIFxGcvEoJxNRySsBuDvb2" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1138,977,45,19" Id="TajWSfbwTRMQDreo6zTDze">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -4000,7 +4000,7 @@
                 <Pin Id="PdkDW1aQSvfLxdNz0guYTZ" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1157,1006,45,19" Id="TtRkzmAqZNQLBcd8qeUP5s">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -4010,7 +4010,7 @@
                 <Pin Id="RynX7N0ZBuEPyjOFlQy1ne" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1180,1034,45,19" Id="BVEY4cEuiSVM1xuLu92gtB">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -4021,7 +4021,7 @@
               </Node>
               <Pad Id="S9ySvK2vBHjLI5Tf6IFACO" Comment="" Bounds="873,742,35,43" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="563,727,45,19" Id="NhTDPPB80o6MCBY49NJMTy">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -4032,7 +4032,7 @@
               </Node>
               <Pad Id="Ugvz6Uq5P4cPKqEnWhHb07" Comment="" Bounds="569,763,35,43" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="929,587,22,19" Id="NoSnH5v2A1MLBV4Vtf0lkj">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                 </p:NodeReference>
@@ -4040,7 +4040,7 @@
                 <Pin Id="RCaWJ6sQ26qQcBe5pBBVf2" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1199,603,48,19" Id="HLr3Ng7AqyPNbsqkRGWhYN">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Length" />
                 </p:NodeReference>
@@ -4048,7 +4048,7 @@
                 <Pin Id="Sf3C9aCpKJWOsGpcWPxF74" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1199,633,34,19" Id="Sn6ywUcWeRnQFWvHoOnoAW">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Abs" />
                 </p:NodeReference>
@@ -4057,42 +4057,42 @@
               </Node>
               <Pad Id="Go5a1HKCN6XMH9788O0zoN" Comment="" Bounds="1213,668,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="1199,738,85,19" Id="MKhZkCvU4DjQARnsiCl1ty">
-                <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="MapClamp" />
                 </p:NodeReference>
                 <Pin Id="TF3aWSXC440NwZ4oHP4bM0" Name="Input" Kind="InputPin" />
                 <Pin Id="SpqWuEi4VO2N7ZAv5JqSUX" Name="Input Minimum" Kind="InputPin" DefaultValue="0.13">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="QvXWJPa3wZ4Nibe6zWx1gQ" Name="Input Maximum" Kind="InputPin" DefaultValue="0.08">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="NP0FcZQFtijLMI3tuhrlZz" Name="Output Minimum" Kind="InputPin" />
                 <Pin Id="TXS1t6lbGZpMrq8x0nhoJx" Name="Output Maximum" Kind="InputPin" DefaultValue="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="LgMMWNraH3WNMIod9Tqlp5" Name="Output" Kind="OutputPin" />
               </Node>
               <Pad Id="GUs0KAZydmYOKYWDEs4ek2" Comment="Input Minimum" Bounds="1221,694,35,15" ShowValueBox="true" isIOBox="true" Value="0.09999999">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="BO82jqowHjvMzPWvTA39Sx" Comment="Input Maximum" Bounds="1240,720,35,15" ShowValueBox="true" isIOBox="true" Value="0.05">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="EWoRl2CwQajMH5XkXAmVDg" Comment="" Bounds="1201,777,35,15" ShowValueBox="true" isIOBox="true" />
               <Node Bounds="1382,854,45,19" Id="HADlzGNB6trOanwkGvWyOX">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Lerp" />
                 </p:NodeReference>
@@ -4106,7 +4106,7 @@
               <ControlPoint Id="Q9GObORdNo8O7mtvOR266j" Bounds="1115,379" />
               <ControlPoint Id="PtHCydPKcy3ORZSXBvAdEi" Bounds="1564,390" />
               <Node Bounds="1326,570,67,19" Id="LQKG8WX1hXrOoItXa2I1gU">
-                <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Quaternion (Join)" />
                 </p:NodeReference>
@@ -4114,7 +4114,7 @@
                 <Pin Id="CVtKusNd1vuMPEg5p1xtdu" Name="Y" Kind="InputPin" />
                 <Pin Id="Tb8XpXMh9PWLRsSzXeFx5Y" Name="Z" Kind="InputPin" />
                 <Pin Id="KBsPnKJfHjZOqXQ4GNnNah" Name="W" Kind="InputPin" DefaultValue="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -4262,7 +4262,7 @@
 
 -->
         <Node Name="DeviceTransformation" Bounds="385,394" Id="FJ2UG0y7nWXPo27IO4QASb">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="Kko7cnZUgqROQkib8GZVqM">
@@ -4270,7 +4270,7 @@
               <ControlPoint Id="Tu1oAklVYTjO8qYM1xTT75" Bounds="445,319" />
               <ControlPoint Id="Hfww13qz7pDMppAjo1Ttkk" Bounds="597,313" />
               <Node Bounds="441,361,87,26" Id="SIJk8az7gsMOhVlRZNylgI">
-                <p:NodeReference>
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" />
                   <Choice Kind="OperationCallFlag" Name="GetImuSamples" />
@@ -4280,7 +4280,7 @@
                 <Pin Id="MWrkZhcxL0qNM4HZeks0XH" Name="Samples" Kind="OutputPin" />
               </Node>
               <Node Bounds="507,502,175,220" Id="JE2Olj4rSMXLXDFKymobK9">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="ProcessAppFlag" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -4297,7 +4297,7 @@
                   <ControlPoint Id="KOJ65bXVG37N7GbwHZQSwV" Bounds="518,510" />
                   <ControlPoint Id="AmCTwu28iWsPrjhoJFfsFr" Bounds="512,715" />
                   <Node Bounds="519,568,151,19" Id="Ai18Du7ZdUXMfBpnWoqeIl">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="DeviceTransformationInternal" />
                     </p:NodeReference>
@@ -4307,7 +4307,7 @@
                 </Patch>
               </Node>
               <Node Bounds="522,440" Id="TEET8Ah42n1OYFxHO9lrPM">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch" />
                   <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -4318,7 +4318,7 @@
                 <Pin Id="S2UvsFdmwpYLkjsx9g7gf1" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="507,771,65,19" Id="A4MWKApk1ShLzYS19UM662">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                 </p:NodeReference>
@@ -4330,17 +4330,6 @@
               <ControlPoint Id="VwnB72gSGqWOd453xHPVWS" Bounds="506,835" />
               <ControlPoint Id="QHzu1a5RFuOMtDdqsBkfHq" Bounds="588,814" />
             </Canvas>
-            <Patch Id="IwQ5ICWA9XbLlMJsDp1h5I" Name="Create" />
-            <Patch Id="LMYvSItJlNNMoW1XJ0Vm7d" Name="Update">
-              <Pin Id="EDec3C1HB8qObMQGvwSRo8" Name="Device" Kind="InputPin" Bounds="321,271" />
-              <Pin Id="Lmy6klNPeVHPiXPaZ7UiDo" Name="Enable" Kind="InputPin" Bounds="274,196" DefaultValue="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="TypeFlag" Name="Boolean" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="EPTV8bbByHHLT3JKog2M1k" Name="Position" Kind="OutputPin" Bounds="512,721" />
-              <Pin Id="LwezeX4I0tvM53IaBieGNc" Name="On Data" Kind="OutputPin" Bounds="594,697" />
-            </Patch>
             <ProcessDefinition Id="JGVS6jIKAQSLXeFh1TXZEx">
               <Fragment Id="Kyio3YRezbYNUlLM6y8Pof" Patch="IwQ5ICWA9XbLlMJsDp1h5I" Enabled="true" />
               <Fragment Id="TNQxPE4WDfmOeBxJFmKufa" Patch="LMYvSItJlNNMoW1XJ0Vm7d" Enabled="true" />
@@ -4360,6 +4349,17 @@
             <Link Id="LzcA4TFTNLVMm3Qww3cTmP" Ids="VwnB72gSGqWOd453xHPVWS,EPTV8bbByHHLT3JKog2M1k" IsHidden="true" />
             <Link Id="BMtlYivz3khLVBw6kNq9w4" Ids="SFkcXxTCPJZL18YNFmT7UB,QHzu1a5RFuOMtDdqsBkfHq" />
             <Link Id="HfxM8887SGfLFBF5YaELhA" Ids="QHzu1a5RFuOMtDdqsBkfHq,LwezeX4I0tvM53IaBieGNc" IsHidden="true" />
+            <Patch Id="IwQ5ICWA9XbLlMJsDp1h5I" Name="Create" />
+            <Patch Id="LMYvSItJlNNMoW1XJ0Vm7d" Name="Update">
+              <Pin Id="EDec3C1HB8qObMQGvwSRo8" Name="Device" Kind="InputPin" Bounds="321,271" />
+              <Pin Id="Lmy6klNPeVHPiXPaZ7UiDo" Name="Enable" Kind="InputPin" Bounds="274,196" DefaultValue="True">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="EPTV8bbByHHLT3JKog2M1k" Name="Position" Kind="OutputPin" Bounds="512,721" />
+              <Pin Id="LwezeX4I0tvM53IaBieGNc" Name="On Data" Kind="OutputPin" Bounds="594,697" />
+            </Patch>
           </Patch>
         </Node>
         <!--
@@ -4367,76 +4367,16 @@
     ************************ PointCloudImage ************************
 
 -->
-        <Node Name="PointCloudImage" Bounds="467,681" Id="NfQ9elVdtPpNEhbnsSXQgS">
+        <Node Name="PointCloudImage" Bounds="715,725" Id="NfQ9elVdtPpNEhbnsSXQgS">
           <p:NodeReference>
             <Choice Kind="ContainerDefinition" Name="Process" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="KRHcoBIOVQjNHxoXzaFcGK">
             <Canvas Id="TlhiS3nfuCDOrGoYlCO7gp" CanvasType="Group">
-              <Node Bounds="353,626,255,230" Id="LKxx48NwTwTQIsEzhJzJHT">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="ForEach" />
-                  <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
-                </p:NodeReference>
-                <Pin Id="AzB9qQSCpSxQGXCYV1YXI0" Name="Messages" Kind="InputPin" />
-                <Pin Id="IYE8RYcZZCuOAPeoIajYFw" Name="Reset" Kind="InputPin" />
-                <Pin Id="EGvjXlaHcHWN2OC4aSoT0F" Name="Result" Kind="OutputPin" />
-                <Patch Id="JNwaP0VR728LcNYP4al0Vp" ManuallySortedPins="true">
-                  <Patch Id="GP1BBOcW4FbPpJ6inIgZwf" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="GtMoEAsYRxgLrBfcAepQut" Name="Update" ManuallySortedPins="true">
-                    <Pin Id="KwZ4lwXcclUNiAegzSF1OD" Name="Input 1" Kind="InputPin" />
-                    <Pin Id="URCinZBrQLKOvgr6qPT8KI" Name="Output" Kind="OutputPin" />
-                  </Patch>
-                  <ControlPoint Id="KJs2mh8gwWPOf7rznEZ1mu" Bounds="359,637" />
-                  <ControlPoint Id="BALt7XBq6RoPKO6B4TuGmc" Bounds="365,849" />
-                  <Node Bounds="368,660,45,26" Id="RTsogIbEJS1Orgo8fLFBRf">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <CategoryReference Kind="AssemblyCategory" Name="Capture" />
-                      <Choice Kind="OperationCallFlag" Name="Depth" />
-                    </p:NodeReference>
-                    <Pin Id="Tvp77CPUji0LRtwOAaWHnL" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="KWwjVb79Y0nOa2gKcvbcRA" Name="Output" Kind="StateOutputPin" />
-                    <Pin Id="Ln126lOZhseLYU5uzMoqik" Name="Depth" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="510,649,86,19" Id="L5H4f6jZmb2PJHofULUCZZ">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Transformation" />
-                    </p:NodeReference>
-                    <Pin Id="NcW5lk4W0OKMNnzW7qu0dJ" Name="Device" Kind="InputPin" />
-                    <Pin Id="IBzQ0yq85chLQxUqZjMoM6" Name="Output" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="376,729,132,26" Id="K6H0RE3mMdLPhkKf3tr6Xn">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
-                      <Choice Kind="OperationCallFlag" Name="DepthImageToPointCloud" />
-                      <PinReference Kind="OutputPin" Name="return" ParameterModifier="return" />
-                    </p:NodeReference>
-                    <Pin Id="IjVNua3Oq5RNbeXoQZt7iv" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="B986i5pGzbxOoTwDXzCwi3" Name="Depth" Kind="InputPin" />
-                    <Pin Id="EEsHIEO8tXGMX51c7vYzlB" Name="Camera" Kind="InputPin" />
-                    <Pin Id="IA6Lz1zj9r4MpBaHr9WGW7" Name="Output" Kind="StateOutputPin" />
-                    <Pin Id="P0u1JHEEh9ENP8Z212AnlG" Name="Result" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="365,790,162,26" Id="VJBWc25CnQPOiS1hXupToo">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="PointCloudeImageToBGRAImage" />
-                    </p:NodeReference>
-                    <Pin Id="GGYUCcarDYlMnH98gP2swe" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="K9lLNd135CsN2KVjOngBD8" Name="Scaling" Kind="InputPin" />
-                    <Pin Id="OeUD3v6yQfPMCYXpx3ugNm" Name="Result" Kind="OutputPin" />
-                  </Node>
-                </Patch>
-              </Node>
-              <ControlPoint Id="RlNjlamhk5LLljviNFNUzl" Bounds="336,275" />
-              <ControlPoint Id="PcVXziDth95OaLCLtcRgfU" Bounds="353,928" />
-              <Node Bounds="351,882,88,19" Id="Q4oF7d5qNZlMym6XvJ8m4R">
-                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+              <ControlPoint Id="PcVXziDth95OaLCLtcRgfU" Bounds="412,688" />
+              <Node Bounds="410,642,88,19" Id="Q4oF7d5qNZlMym6XvJ8m4R">
+                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
                 </p:NodeReference>
@@ -4447,85 +4387,35 @@
                 <Pin Id="RGv3F1GWHWJMCFGhdzg2IV" Name="Swap Count" Kind="OutputPin" />
                 <Pin Id="IpH9MQnHpk6PWCghjk4BSz" Name="Drop Count" Kind="OutputPin" />
               </Node>
-              <Node Bounds="334,403,83,26" Id="NqbAUlBcdd4MbgDzvYVK3Q">
-                <p:NodeReference>
+              <Node Bounds="410,523,94,19" Id="Bh3tcI3iPZhPlw3Wvdt92P">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
-                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                  <Choice Kind="ProcessAppFlag" Name="PointCloudImage (Reactive)" />
                 </p:NodeReference>
-                <Pin Id="SiKURF0Xl8ALqqk3jtmEJx" Name="Input" Kind="StateInputPin" />
-                <Pin Id="T1ED1TmtwZgN6lI8BXb0Je" Name="Output" Kind="StateOutputPin" />
-                <Pin Id="GqH3pNb7OVJN8CJz3gTYuN" Name="Captures" Kind="OutputPin" />
+                <Pin Id="Rf5mUjNZv5bOiXKQ973OS0" Name="Device" Kind="InputPin" />
+                <Pin Id="ERsk61ozr5NMTJuq8fWABV" Name="Scaling" Kind="InputPin" />
+                <Pin Id="KHr3NKOmLtKQXH8hGikBuN" Name="Output" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="H2FixasK01vOsypGmDpHqA" Bounds="620,294" />
-              <Node Bounds="353,491,129,107" Id="Ogi5sBuKLZYMHvvaVMKRr9">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
-                  <Choice Kind="ProcessAppFlag" Name="Where" />
-                  <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
-                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                </p:NodeReference>
-                <Pin Id="TZULEISqxRTP4cLQV812Hi" Name="Value" Kind="InputPin" />
-                <Pin Id="PfpqwINAK7CP6KuQtB4r60" Name="Result" Kind="OutputPin" />
-                <Pin Id="CPICC6Q916RLQnv5f8Cdgh" Name="Changed" Kind="OutputPin" />
-                <Patch Id="PpnxuLfK5AjPc8xN7QRtAz" Name="Predicate" ManuallySortedPins="true">
-                  <Pin Id="C34u2v8juqeLaLfwAMZrXO" Name="Input" Kind="InputPin" />
-                  <Pin Id="F2OgBo8c5JUOULHCrhXWHt" Name="Result" Kind="OutputPin" />
-                  <ControlPoint Id="GnAVFgxqBsdL5QvJuhjVVr" Bounds="365,502" />
-                  <ControlPoint Id="MqDobajE7HZLt789Koyl3O" Bounds="361,591" />
-                  <Node Bounds="365,514,45,26" Id="Jycb6vILUfuNyOrkpSeyVx">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Capture" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <CategoryReference Kind="AssemblyCategory" Name="Capture" />
-                      <Choice Kind="OperationCallFlag" Name="Depth" />
-                    </p:NodeReference>
-                    <Pin Id="PeprjyHaGbIO4Xo44Ol0KV" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="RWiUhe289qmPe7frbjqzLV" Name="Output" Kind="StateOutputPin" />
-                    <Pin Id="QtZ01B1nb8UPo378fBm0ug" Name="Depth" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="405,550,65,19" Id="Q8ZQwn3B39gObcR4tu1MN3">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-                    </p:NodeReference>
-                    <Pin Id="A3QFNZI0KnnOGspf4HsPLh" Name="X" Kind="InputPin" />
-                    <Pin Id="DjIwie9MjbJOorrkoTvzEO" Name="Result" Kind="OutputPin" />
-                    <Pin Id="AvPFeMolHu1MPo6RnjaT3i" Name="Not Assigned" Kind="OutputPin" />
-                  </Node>
-                </Patch>
-              </Node>
+              <ControlPoint Id="Iek3OE5CBJdMRIyZrTPu4l" Bounds="412,440" />
+              <ControlPoint Id="V8LtTsPoDDWLY0OusNHnI1" Bounds="501,440" />
             </Canvas>
             <Patch Id="EYerKYF4AoKNJqj21NC4kc" Name="Create" />
             <Patch Id="N5gnT62hPj5PRBfbTDCqzV" Name="Update">
-              <Pin Id="IPABJA531w7Lub46BpQQae" Name="Sensor" Kind="InputPin" Bounds="180,751" />
-              <Pin Id="RI9pX4aXA6NLiMZlhw5XxB" Name="Scaling" Kind="InputPin" Bounds="619,293" />
               <Pin Id="JUJ0tsAeflLPqwCLOf8ST7" Name="Output" Kind="OutputPin" Bounds="104,965" />
+              <Pin Id="Tng3zsYFkn1NZA7N2zarhZ" Name="Device" Kind="InputPin" Bounds="412,440" />
+              <Pin Id="J2t1MnNzwCvOhyoRfNFwGF" Name="Scaling" Kind="InputPin" Bounds="501,444" DefaultValue="0.001" />
             </Patch>
             <ProcessDefinition Id="R7SoibYuUPhMD1Onws6vPf">
               <Fragment Id="RRLJN17wxJFN2H9K2XABUQ" Patch="EYerKYF4AoKNJqj21NC4kc" Enabled="true" />
               <Fragment Id="PJsnSvZX2rLMc1OgfY0SLr" Patch="N5gnT62hPj5PRBfbTDCqzV" Enabled="true" />
             </ProcessDefinition>
-            <Link Id="MQoOox3hrutMxFu4C16xPm" Ids="KwZ4lwXcclUNiAegzSF1OD,KJs2mh8gwWPOf7rznEZ1mu" IsHidden="true" />
-            <Link Id="RUbzp4SjaU4PtfevygnYZW" Ids="BALt7XBq6RoPKO6B4TuGmc,URCinZBrQLKOvgr6qPT8KI" IsHidden="true" />
-            <Link Id="Kz4u9sR3Y07QAPJCAEAtD1" Ids="KJs2mh8gwWPOf7rznEZ1mu,Tvp77CPUji0LRtwOAaWHnL" />
-            <Link Id="KMYiGAIu0o8NLElpgBdnb5" Ids="RlNjlamhk5LLljviNFNUzl,SiKURF0Xl8ALqqk3jtmEJx" />
-            <Link Id="Aeuenz6MzkeNVjY1dUlnEs" Ids="IPABJA531w7Lub46BpQQae,RlNjlamhk5LLljviNFNUzl" IsHidden="true" />
             <Link Id="RofMWTh3Xi5OJXelJPNEHM" Ids="PcVXziDth95OaLCLtcRgfU,JUJ0tsAeflLPqwCLOf8ST7" IsHidden="true" />
-            <Link Id="UrFNDWTytOPMuRr2OWDg5h" Ids="EGvjXlaHcHWN2OC4aSoT0F,EObRXlHtFfNPQNKspyClj6" />
-            <Link Id="CVQ0o6KljKQLVrfMRNaln7" Ids="IBzQ0yq85chLQxUqZjMoM6,IjVNua3Oq5RNbeXoQZt7iv" />
-            <Link Id="QMJ5FvcRlK2M5ec094bWdR" Ids="Ln126lOZhseLYU5uzMoqik,B986i5pGzbxOoTwDXzCwi3" />
-            <Link Id="GhYjHbZI0eDO6rBNdCjiox" Ids="RlNjlamhk5LLljviNFNUzl,NcW5lk4W0OKMNnzW7qu0dJ" />
-            <Link Id="EdFM1x6IMS7LaQ6oVeJE9E" Ids="RI9pX4aXA6NLiMZlhw5XxB,H2FixasK01vOsypGmDpHqA" IsHidden="true" />
-            <Link Id="LnG3UCYXM6GPFbwbDsW37X" Ids="P0u1JHEEh9ENP8Z212AnlG,GGYUCcarDYlMnH98gP2swe" />
-            <Link Id="HIuOg0Ji73CMiKxoGFYtcN" Ids="H2FixasK01vOsypGmDpHqA,K9lLNd135CsN2KVjOngBD8" />
-            <Link Id="AtJI0ffXZW3MChdgVjECyp" Ids="OeUD3v6yQfPMCYXpx3ugNm,BALt7XBq6RoPKO6B4TuGmc" />
             <Link Id="Gv3jvJqI6xCOrNVHWIMKMr" Ids="HlQpyzYT1xNMlIfAAmEBFL,PcVXziDth95OaLCLtcRgfU" />
-            <Link Id="Fvw7zQdju0DNHRP47bBRN4" Ids="GqH3pNb7OVJN8CJz3gTYuN,TZULEISqxRTP4cLQV812Hi" />
-            <Link Id="LAGxzjXCUHCLigLabyd3h5" Ids="C34u2v8juqeLaLfwAMZrXO,GnAVFgxqBsdL5QvJuhjVVr" IsHidden="true" />
-            <Link Id="Q17glFas8rNO4n027bQhhh" Ids="MqDobajE7HZLt789Koyl3O,F2OgBo8c5JUOULHCrhXWHt" IsHidden="true" />
-            <Link Id="Vs82heY88NPLmZkycx48ug" Ids="PfpqwINAK7CP6KuQtB4r60,AzB9qQSCpSxQGXCYV1YXI0" />
-            <Link Id="IIbVEdcislNNmdT2ESJxAj" Ids="GnAVFgxqBsdL5QvJuhjVVr,PeprjyHaGbIO4Xo44Ol0KV" />
-            <Link Id="FmxCuQRyE6mMpgvFnGFBkJ" Ids="QtZ01B1nb8UPo378fBm0ug,A3QFNZI0KnnOGspf4HsPLh" />
-            <Link Id="ApwGXp7dYSrPj28BkGeYhT" Ids="DjIwie9MjbJOorrkoTvzEO,MqDobajE7HZLt789Koyl3O" />
+            <Link Id="ChMDBMiC8Y8QBm7UvvcdDU" Ids="KHr3NKOmLtKQXH8hGikBuN,EObRXlHtFfNPQNKspyClj6" />
+            <Link Id="FCDniJunXWUPJGKrZtPdTC" Ids="Iek3OE5CBJdMRIyZrTPu4l,Rf5mUjNZv5bOiXKQ973OS0" />
+            <Link Id="UAfmeqvXcqzNJAKpRkJYEK" Ids="Tng3zsYFkn1NZA7N2zarhZ,Iek3OE5CBJdMRIyZrTPu4l" IsHidden="true" />
+            <Link Id="L5cfs4AuOEGL6HnU75k6BE" Ids="V8LtTsPoDDWLY0OusNHnI1,ERsk61ozr5NMTJuq8fWABV" />
+            <Link Id="AUvEmEci34lPWKIgP0ECfM" Ids="J2t1MnNzwCvOhyoRfNFwGF,V8LtTsPoDDWLY0OusNHnI1" IsHidden="true" />
           </Patch>
         </Node>
         <!--
@@ -4534,7 +4424,7 @@
 
 -->
         <Node Name="DepthRayTable" Bounds="461,583" Id="DY5dj0FqrxEMW1TIyHDqe4">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="AFfroFLh8gJQJsJiAlcWCw">
@@ -4542,7 +4432,7 @@
               <ControlPoint Id="QxfTYzOrzYLOWYyh3XkSmN" Bounds="149,699" />
               <ControlPoint Id="DMpmI5Qd67jLJruv0Qv9ZV" Bounds="408,707" />
               <Node Bounds="54,231,446,274" Id="D5szjXl3KI2Pa2bKx9mfen">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -4550,14 +4440,14 @@
                 <Pin Id="AS2FAvXCHVYMufRJcPOktx" Name="Force" Kind="InputPin" />
                 <Pin Id="KAorbmGsRa9MPAVMXhdWMG" Name="Dispose Cached Outputs" Kind="InputPin" />
                 <Pin Id="UWZ8YQ9emYAM5K5wH3YgA4" Name="Has Changed" Kind="OutputPin" />
-                <ControlPoint Id="VTUH0rtqlpsNrUsN2pGZwB" Bounds="391,238" Alignment="Top" />
-                <ControlPoint Id="KGECytKVlkhLqkgslOHenj" Bounds="395,312" Alignment="Bottom" />
+                <ControlPoint Id="VTUH0rtqlpsNrUsN2pGZwB" Bounds="391,237" Alignment="Top" />
+                <ControlPoint Id="KGECytKVlkhLqkgslOHenj" Bounds="395,499" Alignment="Bottom" />
                 <ControlPoint Id="TNGgBObYYvdOU69ktKerpT" Bounds="144,499" Alignment="Bottom" />
                 <Patch Id="FfUfwu3xWRvPQqZZjLoQBE" ManuallySortedPins="true">
                   <Patch Id="H7RXA532fr9OcnkFbSkoXs" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="RZCiU6ZXA8rMg023lQdnCf" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="381,264,107,19" Id="T2ULFZWrInLQYViGH241bt">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PointCloudUtils" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PointCloudUtils" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="BuildDepthRayTable" />
                     </p:NodeReference>
@@ -4565,7 +4455,7 @@
                     <Pin Id="JLcAEezCNn8NmWpmN18iRR" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="141,466,205,19" Id="O03qoNJH5GzN7qohy08QCr">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures" LastSymbolSource="VL.Stride.Graphics.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Stride" />
                       <CategoryReference Kind="Category" Name="Textures" />
@@ -4580,7 +4470,7 @@
                     <Pin Id="EEfECVAiKuuMsJxP6qqwXv" Name="Has Changed" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="111,280,128,26" Id="LD9QbPIIN5hPAxOVBBWuoD">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Calibration" />
                       <Choice Kind="OperationCallFlag" Name="DepthCameraCalibration" />
@@ -4590,7 +4480,7 @@
                     <Pin Id="SulmnLGMbKIPUXIybhOOKK" Name="Depth Camera Calibration" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="66,326,90,26" Id="CgvUDfeduoIOAca0phLqmE">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionWidth" />
                     </p:NodeReference>
@@ -4599,7 +4489,7 @@
                     <Pin Id="PLNAbdWTrPLNd6wYcZIqIE" Name="Resolution Width" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="166,326,94,26" Id="HWSBAiggJL0P4OWO5DGE34">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionHeight" />
                     </p:NodeReference>
@@ -4608,12 +4498,12 @@
                     <Pin Id="EfeB6I4SrG8NU6ylSNGUmi" Name="Resolution Height" Kind="OutputPin" />
                   </Node>
                   <Pad Id="PNUrw3Xlh5GOTWVpZ99f9j" Comment="Format" Bounds="244,447,172,15" ShowValueBox="true" isIOBox="true" Value="R32G32_Float">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
                       <Choice Kind="TypeFlag" Name="PixelFormat" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="151,397,34,19" Id="NobYfz3vyRDNxAe2M7KLy0">
-                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Int2 (Create)" />
                     </p:NodeReference>
@@ -4660,7 +4550,7 @@
 
 -->
         <Node Name="ColorRayTable" Bounds="461,628" Id="DUzJpuB2EPyNzttLX52SwP">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="Fo9IzBqIBmJOIBgdUPfb2Q">
@@ -4668,7 +4558,7 @@
               <ControlPoint Id="AVSS3bbX95mN8IvH9V62sk" Bounds="400,1002" />
               <ControlPoint Id="A8jofsmtjSnQQ9gtceUwBP" Bounds="659,1010" />
               <Node Bounds="305,534,446,274" Id="CNC4C1kFHAzLKVNd5Rfme8">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -4683,7 +4573,7 @@
                   <Patch Id="MTBDq2yLhwhOJLvbRRaIan" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="BwmlbtL2JzpMdohrcWgv12" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="632,567,107,19" Id="S3jwzctKykCOSfkrixF5Vg">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PointCloudUtils" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PointCloudUtils" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="BuildColorRayTable" />
                     </p:NodeReference>
@@ -4691,7 +4581,7 @@
                     <Pin Id="TqM8NlBrfjAL4H6DiMaEWY" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="392,769,205,19" Id="MvUnjf68HhVOF8MH7yrEx5">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures" LastSymbolSource="VL.Stride.Graphics.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Stride" />
                       <CategoryReference Kind="Category" Name="Textures" />
@@ -4706,7 +4596,7 @@
                     <Pin Id="MyBjZ7PDXXlMsIJAgecTmf" Name="Has Changed" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="362,583,128,26" Id="Edt2xspi3dhOi6gRTdX5iC">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Calibration" />
                       <Choice Kind="OperationCallFlag" Name="ColorCameraCalibration" />
@@ -4716,7 +4606,7 @@
                     <Pin Id="MNN3ZiLhcoEMcKFCd2PsDd" Name="Color Camera Calibration" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="317,629,90,26" Id="Ghbhvh72YLhLAam2ExH5qC">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionWidth" />
                     </p:NodeReference>
@@ -4725,7 +4615,7 @@
                     <Pin Id="IkietDdXyfKLwYoJw2pEet" Name="Resolution Width" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="417,629,94,26" Id="NJt8V5o4YdJLy0cbEe9QHK">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.CameraCalibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ResolutionHeight" />
                     </p:NodeReference>
@@ -4734,12 +4624,12 @@
                     <Pin Id="MwXY4NM1AX8PTnpdHv7uo2" Name="Resolution Height" Kind="OutputPin" />
                   </Node>
                   <Pad Id="QuSDr3VABrrNYRCDXAh6Mn" Comment="Format" Bounds="495,750,172,15" ShowValueBox="true" isIOBox="true" Value="R32G32_Float">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
                       <Choice Kind="TypeFlag" Name="PixelFormat" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="402,700,34,19" Id="MI3ICC0m7hHO01n2l1Z35q">
-                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Int2 (Create)" />
                     </p:NodeReference>
@@ -4786,13 +4676,13 @@
 
 -->
         <Node Name="PointCloudEntity" Bounds="726,496" Id="BUNWp9S48SALCezYyxdEEy">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="SAm8fUwP1sJPajFRSIFTZ9">
             <Canvas Id="N143L0KTy8vOJHKeVdMhvt" CanvasType="Group">
               <Node Bounds="332,735,119,19" Id="VIC3xieY01CMuuSsUWbPBB">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\dev\vvvv\vl-libs_kinect\VL.Devices.AzureKinect)">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessNode" Name="AzureBuildPointCloud" />
                 </p:NodeReference>
@@ -4803,7 +4693,7 @@
                 <Pin Id="LiSLX5oHZKILo7anuANPfV" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="332,338,73,19" Id="FVdyR8sAdy0MZM59CHEMmg">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Texture" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="LoadTexture" />
                 </p:NodeReference>
@@ -4812,7 +4702,7 @@
                 <Pin Id="UVroSoJ1B08QBeslERcdkY" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="633,236,129,19" Id="P6sLAJeDofDLDuMbEqcTYf">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Operations" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Operations" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="DivMod" />
                 </p:NodeReference>
@@ -4821,7 +4711,7 @@
                 <Pin Id="AMV6qMWYMm8QNWUhz5JI17" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="447,337,190,19" Id="UgCpLWqWRzyL2gs7iqSArg">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Texture" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="LoadTexture" />
                 </p:NodeReference>
@@ -4830,7 +4720,7 @@
                 <Pin Id="LOCaYg4HB1jPnekDypwXtF" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="332,841,64,19" Id="PEEVsOdrItCMP5UFpgCark">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Operations" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Operations" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Transform" />
                   <CategoryReference Kind="Category" Name="Operations" NeedsToBeDirectParent="true" />
@@ -4840,14 +4730,14 @@
                 <Pin Id="R1Mi3JPGxhlNnob1ln6QLl" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="391,773,109,19" Id="SJAPcMkzCfUOwNVhnKnp6C">
-                <p:NodeReference LastCategoryFullName="Xenko.Rendering.Shaders.TransformationKeys" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.API.Rendering.TransformationKeys" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="WorldViewProjection" />
                 </p:NodeReference>
                 <Pin Id="LZt025wLN6BOrDZjEvwpkz" Name="World View Projection" Kind="OutputPin" />
               </Node>
               <Node Bounds="476,1007,92,19" Id="Er894WW75hYNIMsp8mUfHe">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Texture" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="LoadTexture" />
                 </p:NodeReference>
@@ -4856,7 +4746,7 @@
                 <Pin Id="NEmAMQHd35SOFVFKfB5L7I" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="563,964,83,19" Id="RhqBRtyxsDhLKW9cBtVFO7">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Variables" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessNode" Name="GetExistingVar" />
                 </p:NodeReference>
@@ -4864,7 +4754,7 @@
                 <Pin Id="VbpZlsqZS1UM1zCHmlkw4u" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="757,162,51,19" Id="VRsFfjI4vo5NHvoRp3eyIC">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -4873,7 +4763,7 @@
                 <Pin Id="Sp4hB015FaZOEZAXQiA7Fz" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="757,199,58,19" Id="HmHFcALDH2GOGjDQYo0HUT">
-                <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToUInt32" />
                 </p:NodeReference>
@@ -4883,7 +4773,7 @@
               <ControlPoint Id="NuSPQlHuEmjNBUnj0bJrSu" Bounds="180,1023" />
               <ControlPoint Id="Cj8UzUnply2LeFlmAIkJi1" Bounds="739,3" />
               <Node Bounds="632,167,70,19" Id="SzFod8ZOdg6PfQZqkhQ8Hr">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX.Variables" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="SV_VertexId" />
                 </p:NodeReference>
@@ -4892,17 +4782,17 @@
               <ControlPoint Id="GXFRfzNBUmaO7BczGXjoLl" Bounds="478,920" />
               <ControlPoint Id="SVEQMttdQoOPkSxtlgW3jz" Bounds="298,1380" />
               <Pad Id="HUu4DNFr9h5PXDhwCpnZnZ" Comment="Profiling Name" Bounds="456,1212,143,15" ShowValueBox="true" isIOBox="true" Value="Kinect Point Cloud ShaderFX">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="P5ks6lcWy39PatAAuXYkKW" Comment="" Bounds="424,933,35,57" ShowValueBox="true" isIOBox="true" Value="1, 1, 1, 1">
-                <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Vector4" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="368,1051,113,19" Id="AEfhflroaLgNolLbQWtwnD">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Switch" />
                   <CategoryReference Kind="Category" Name="ShaderFX" NeedsToBeDirectParent="true" />
@@ -4914,38 +4804,38 @@
               </Node>
               <ControlPoint Id="L3iCk368ThlNvXZfIpT3GY" Bounds="370,901" />
               <Node Bounds="480,1291,45,19" Id="Ksv3qgYIvunNYSEFup324C">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
                 </p:NodeReference>
                 <Pin Id="C7oAKqAxo5eN4DgFdFVCxg" Name="Condition" Kind="InputPin" />
                 <Pin Id="NHOpjAcN2geMvrxGUd0PXj" Name="Input" Kind="InputPin" DefaultValue="PointList">
-                  <p:TypeAnnotation LastCategoryFullName="Xenko.LowLevelAPI.Rendering" LastSymbolSource="VL.Xenko.Graphics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="PrimitiveType" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="GxNszSsjfTJLWULmCo2EaO" Name="Input 2" Kind="InputPin" DefaultValue="TriangleList">
-                  <p:TypeAnnotation LastCategoryFullName="Xenko.LowLevelAPI.Rendering" LastSymbolSource="VL.Xenko.Graphics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="PrimitiveType" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="KEUqgJT51hoLYksxdwN8uP" Name="Output" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="FhYex3CAj6vNoUmLlNtwdP" Bounds="372,0" />
-              <Node Bounds="435,139,106,131" Id="Lm9gyvfEnh5M5UlFr7QooB">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <Node Bounds="435,139,109,132" Id="Lm9gyvfEnh5M5UlFr7QooB">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
                 <Pin Id="TRGAdPtMmgkM0vAlQ05WRf" Name="Condition" Kind="InputPin" />
                 <ControlPoint Id="TXbSWTfgy7lQKh08O2uD9b" Bounds="449,265" Alignment="Bottom" />
-                <ControlPoint Id="BhNFUQSzyB1P0evSkFmAFR" Bounds="457,146" Alignment="Top" />
+                <ControlPoint Id="BhNFUQSzyB1P0evSkFmAFR" Bounds="457,145" Alignment="Top" />
                 <Patch Id="B66KiCgfaKqPouj2FXyA33" ManuallySortedPins="true">
                   <Patch Id="K7JPkCmQIMiNWVu6loZd4t" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="DQGl1jTW8e3PEwx6X743Ea" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="447,216,82,19" Id="EuJ7CEpu70qM3HfkysnY7x">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                  <Node Bounds="447,216,85,19" Id="EuJ7CEpu70qM3HfkysnY7x">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="DepthRayTable" />
                     </p:NodeReference>
@@ -4954,7 +4844,7 @@
                     <Pin Id="TJTOy6AoMdRLRM0LU97bB8" Name="XY Table" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="447,176,46,26" Id="V1oxyHvlUtwQdcXVHASj8G">
-                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Nullable" />
                       <Choice Kind="OperationCallFlag" Name="Value" />
@@ -4966,7 +4856,7 @@
                 </Patch>
               </Node>
               <Node Bounds="447,91,65,26" Id="MTv5jEZGGU9MdL02b5Fv65">
-                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Nullable" />
                   <Choice Kind="OperationCallFlag" Name="HasValue" />
@@ -4976,7 +4866,7 @@
                 <Pin Id="FRV6ESVSVzXOjcDYCSiTLN" Name="Has Value" Kind="OutputPin" />
               </Node>
               <Node Bounds="391,807,33,19" Id="IlkiH6ZT4cvPE3qmHN5Piv">
-                <p:NodeReference LastCategoryFullName="Xenko.ShaderFX" LastSymbolSource="VL.Xenko.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Key" />
                   <CategoryReference Kind="Category" Name="ShaderFX" NeedsToBeDirectParent="true" />
@@ -4985,7 +4875,7 @@
                 <Pin Id="JD0kIWKVefbQLJB4r2jFbe" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="295,1123,78,19" Id="Qc8P8TTmbgBNfuHDstnaDS">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Stride" />
                   <CategoryReference Kind="Category" Name="Rendering" />
@@ -4998,7 +4888,7 @@
                 <Pin Id="FPd4wpNtcbFQE2OK24Nr62" Name="Last Error" Kind="OutputPin" />
               </Node>
               <Node Bounds="447,285,60,19" Id="JNWYQSrR2KYLObxq5Gm0Kv">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="TextureIn" />
                 </p:NodeReference>
@@ -5006,7 +4896,7 @@
                 <Pin Id="CrzinZCotZHQBMaejerGf1" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="476,964,60,19" Id="TbAVTOwTr4gNaUZxH7oXYc">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="TextureIn" />
                 </p:NodeReference>
@@ -5014,7 +4904,7 @@
                 <Pin Id="GAtWCBB80k3NIm6mZNS863" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="368,926,25,19" Id="Ea5ubBC2JdTPbk8Vz8C1As">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Stride" />
                   <CategoryReference Kind="Category" Name="ShaderFX" />
@@ -5024,7 +4914,7 @@
                 <Pin Id="IhJtC89o6FgLIXlFGkGlc1" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="422,1007,25,19" Id="R9mxUPZCqrOMXfqgztl1Xa">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Stride" />
                   <CategoryReference Kind="Category" Name="ShaderFX" />
@@ -5034,7 +4924,7 @@
                 <Pin Id="Us9dXWAEP4bQLObErYQvQB" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="737,38,105,19" Id="BVFvBHlSKnLMcSfvHGMW9V">
-                <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastSymbolSource="VL.Stride.Graphics.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Stride" />
                   <Choice Kind="OperationCallFlag" Name="Info" />
@@ -5051,7 +4941,7 @@
                 <Pin Id="Hbj5r9LC4NFMGTQMZJxiGW" Name="Exists" Kind="OutputPin" />
               </Node>
               <Node Bounds="757,75,34,19" Id="JVyqhMKdtEnP7SWIfb5PAW">
-                <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
                 </p:NodeReference>
@@ -5060,7 +4950,7 @@
                 <Pin Id="LkRGg2GrCYiPpjrlEsl2gE" Name="Y" Kind="OutputPin" />
               </Node>
               <Node Bounds="332,298,60,19" Id="TovOQ8r3ld0NzkBc1tPYRi">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Texture" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="TextureIn" />
                 </p:NodeReference>
@@ -5068,7 +4958,7 @@
                 <Pin Id="ABZHlAb7amQP7QGUsVYKfg" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="370,19,82,26" Id="R5MjUG9LExfNuC1q3KBilU">
-                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" />
                   <Choice Kind="OperationCallFlag" Name="GetCalibration" />
@@ -5078,7 +4968,7 @@
                 <Pin Id="HScER87VugGMTAxwmL4UcP" Name="Calibration" Kind="OutputPin" />
               </Node>
               <Node Bounds="447,58,65,19" Id="EMS6Ly8N9auK96FsESyIKE">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                 </p:NodeReference>
@@ -5088,7 +4978,7 @@
                 <Pin Id="OLs9rx7XzvAOOJRNBQpMZv" Name="On Data" Kind="OutputPin" />
               </Node>
               <Node Bounds="296,1324,215,19" Id="O2enW1jxoTEPKwPdULIsm3">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Runtime.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                 </p:NodeReference>
@@ -5104,7 +4994,7 @@
                 <Pin Id="Sn4Mtd8IPDqQLPzKX6M4GE" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="401,1155,145,19" Id="GapsrWpucTdMUmF3ZSp4x9">
-                <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessNode" Name="PlaneMesh" />
                 </p:NodeReference>
@@ -5119,7 +5009,7 @@
                 <Pin Id="JqQ1tISYqvdOmT8KUHB7Gk" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="401,1123,46,19" Id="G0IKRs3HQdRMZ0LHW7AoSK">
-                <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -5130,7 +5020,7 @@
               </Node>
               <ControlPoint Id="DYsMCvbGgTONMlUwMhiX57" Bounds="398,475" />
               <Node Bounds="396,517,25,19" Id="KvlzCxvn6oQOVcgWMxF9Py">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="=" />
                 </p:NodeReference>
@@ -5138,18 +5028,20 @@
                 <Pin Id="Aq1W07h3wvpPKRYGM7eZ7F" Name="Input 2" Kind="InputPin" />
                 <Pin Id="UuCQFPN0sUvNfZ8cyUZ7I0" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="396,570,100,81" Id="JTtm23RYwO6On7Q6zZMmR5">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <Node Bounds="396,570,100,82" Id="JTtm23RYwO6On7Q6zZMmR5">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
                 <Pin Id="IE4o3FBzUegK9mG37kB8N3" Name="Condition" Kind="InputPin" />
+                <ControlPoint Id="GfFPQEucif6MwJUaNqyNdt" Bounds="410,646" Alignment="Bottom" />
+                <ControlPoint Id="GHh0ZBt2hrTOCsAgMzLHvE" Bounds="428,576" Alignment="Top" />
                 <Patch Id="SQSkCQ41wyYQc6XAIM3abb" ManuallySortedPins="true">
                   <Patch Id="TIdEiWGweZdNii4KBUWdJp" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Dq6VLlJnMVEPnxSiWyp9Vw" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="408,603,76,19" Id="RjXbFN8N5URQNYKfFp6RFS">
-                    <p:NodeReference LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="BoundingBox" />
                     </p:NodeReference>
@@ -5158,11 +5050,9 @@
                     <Pin Id="Mhk6AVyvacRMRWg4Gekku0" Name="Output" Kind="OutputPin" />
                   </Node>
                 </Patch>
-                <ControlPoint Id="GfFPQEucif6MwJUaNqyNdt" Bounds="410,646" Alignment="Bottom" />
-                <ControlPoint Id="GHh0ZBt2hrTOCsAgMzLHvE" Bounds="428,577" Alignment="Top" />
               </Node>
               <Node Bounds="408,677,59,26" Id="H5aM43VZvQDMVIYa4tQkTR">
-                <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="AlignedBox" />
                   <Choice Kind="OperationCallFlag" Name="Minimum" />
@@ -5171,7 +5061,7 @@
                 <Pin Id="VXl8dcFftWpQRC4q26yv5S" Name="Minimum" Kind="OutputPin" />
               </Node>
               <Node Bounds="477,677,61,26" Id="D5R0eud0FyrMIu1vTjBOac">
-                <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="AlignedBox" />
                   <Choice Kind="OperationCallFlag" Name="Maximum" />
@@ -5263,7 +5153,7 @@
     ************************ ColorToDepthImage ************************
 
 -->
-        <Node Name="ColorToDepthImage" Bounds="718,603" Id="TjqJAiMst9pPmpHX6jArrD">
+        <Node Name="ColorToDepthImage" Bounds="715,603" Id="TjqJAiMst9pPmpHX6jArrD">
           <p:NodeReference>
             <Choice Kind="ContainerDefinition" Name="Process" />
             <FullNameCategoryReference ID="Primitive" />
@@ -5271,9 +5161,9 @@
           <Patch Id="KVnF2lwFDpbLkVSCTaJmm1">
             <Canvas Id="JJ1kHX96TdZPwwqfJ9qSPK" CanvasType="Group">
               <ControlPoint Id="JC4IGovnxeAMLhr4KmvL2c" Bounds="172,227" />
-              <ControlPoint Id="FNfEsrLSwLZMBU9Zix9IeA" Bounds="204,692" />
-              <Node Bounds="202,646,88,19" Id="AFCtAkHWqP6PYehCAg2le2">
-                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+              <ControlPoint Id="FNfEsrLSwLZMBU9Zix9IeA" Bounds="172,403" />
+              <Node Bounds="170,357,88,19" Id="AFCtAkHWqP6PYehCAg2le2">
+                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
                 </p:NodeReference>
@@ -5284,115 +5174,18 @@
                 <Pin Id="Hbrzck6FaFwNnqQtWFt0oi" Name="Swap Count" Kind="OutputPin" />
                 <Pin Id="BwM44gETRq2MIoE5hgQKYL" Name="Drop Count" Kind="OutputPin" />
               </Node>
-              <Node Bounds="159,317,246,307" Id="UVnSWZwH3eENTg6MYKyobv">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="JWMUwSr4nxdMTT1F6CeSTn" Name="Force" Kind="InputPin" />
-                <Pin Id="IhyTHSOeeklOOwCrCG3Gfs" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="UhGzOJpLwWhNG3P3TkFskg" Name="Has Changed" Kind="OutputPin" />
-                <ControlPoint Id="MPyJ61bYHHlPNh6IvmjpyD" Bounds="204,619" Alignment="Bottom">
-                  <p:TypeAnnotation>
-                    <Choice Kind="TypeFlag" Name="Observable" />
-                    <p:TypeArguments>
-                      <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Image" />
-                      </TypeReference>
-                    </p:TypeArguments>
-                  </p:TypeAnnotation>
-                </ControlPoint>
-                <ControlPoint Id="N9sHT2a7suqLi5v1SCjmyh" Bounds="185,323" Alignment="Top" />
-                <Patch Id="IBKNh6em2ueP2c9mTD3WLt" ManuallySortedPins="true">
-                  <Patch Id="S3mZ1aBiPzuPlwV1zgr7FC" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="BCS1J83R6uUMYZ0s4M5p1U" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="202,423,191,163" Id="UG2Md0j5prVNS75VgN3pVf">
-                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
-                      <Choice Kind="OperationCallFlag" Name="Select" />
-                      <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
-                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                    </p:NodeReference>
-                    <Pin Id="Rq1OuJR6wgqOi8V2RoTWXz" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="AIr5u96yxIqP9pGMxdaf53" Name="Output" Kind="StateOutputPin" />
-                    <Patch Id="TKhwCZGxmnCOvCNhjbsend" Name="Selector" ManuallySortedPins="true">
-                      <Pin Id="CMhuOIZxkNJMoQX8LXUR9P" Name="Input 1" Kind="InputPin">
-                        <p:TypeAnnotation>
-                          <Choice Kind="TypeFlag" Name="Capture" />
-                          <FullNameCategoryReference ID="Devices.AzureKinect" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="CHDC5zp4bEzNL3KeQnfb2e" Name="Result" Kind="OutputPin">
-                        <p:TypeAnnotation>
-                          <Choice Kind="TypeFlag" Name="Image" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <ControlPoint Id="I85zV97ddtLO0Kwr1jn0y7" Bounds="206,431" />
-                      <ControlPoint Id="CsdrvaVzkMYMPvxLBEShKY" Bounds="207,579" />
-                      <Node Bounds="239,456,142,26" Id="BMHaO6cjiDXOngP74oyGOK">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
-                          <Choice Kind="OperationCallFlag" Name="ColorImageToDepthCamera" />
-                          <PinReference Kind="OutputPin" Name="return" ParameterModifier="return" />
-                          <PinReference Kind="InputPin" Name="Capture" />
-                        </p:NodeReference>
-                        <Pin Id="MJGyBOtVNSXNB5JjboIvqP" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="Q6Nu5s19I99LhzoRKjsAyr" Name="Capture" Kind="InputPin" />
-                        <Pin Id="NSwYFRHXUAdOZd1MrkhrRv" Name="Output" Kind="StateOutputPin" />
-                        <Pin Id="OlgvxEHLNkLOIRdpifmWSI" Name="Result" Kind="OutputPin" />
-                      </Node>
-                      <Node Bounds="237,513,99,26" Id="R6ZPCu32dLxObpZQNTS4mP">
-                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <Choice Kind="OperationCallFlag" Name="AsVLImage" />
-                        </p:NodeReference>
-                        <Pin Id="SDj4PQlfxm3OwA3MXB8H6R" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="ATjTCyn0sQsOgbmRwytxix" Name="Result" Kind="OutputPin" />
-                      </Node>
-                      <Pin Id="BkB3mlZONjbLLwyFjrFnnh" Name="Input 2" Kind="InputPin" />
-                      <ControlPoint Id="Bz2Ts5CF5xyPbumVLGMV5Z" Bounds="332,436" />
-                    </Patch>
-                  </Node>
-                  <Node Bounds="237,343,86,19" Id="MTHiqgoynd9NAsQysGelMU">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Transformation" />
-                    </p:NodeReference>
-                    <Pin Id="IvbylqMY8ePNsdbXYQbmyZ" Name="Device" Kind="InputPin" />
-                    <Pin Id="DafavwAtVCgPDP4NttiuMh" Name="Output" Kind="OutputPin" />
-                  </Node>
-                  <Pad Id="FICM126UDXoNxcS4JQt0tM" Bounds="205,387">
-                    <p:TypeAnnotation>
-                      <Choice Kind="TypeFlag" Name="Observable" />
-                      <p:TypeArguments>
-                        <TypeReference>
-                          <Choice Kind="TypeFlag" Name="Capture" />
-                          <FullNameCategoryReference ID="Devices.AzureKinect" />
-                        </TypeReference>
-                      </p:TypeArguments>
-                    </p:TypeAnnotation>
-                    <p:ValueBoxSettings>
-                      <p:maxvisiblechars p:Type="Int32">44444</p:maxvisiblechars>
-                      <p:showvalue p:Type="Boolean">false</p:showvalue>
-                    </p:ValueBoxSettings>
-                  </Pad>
-                </Patch>
-              </Node>
-              <Node Bounds="156,266,85,26" Id="FtP02szMQJGPGn8TiCK0Bl">
-                <p:NodeReference>
+              <Node Bounds="170,279,108,19" Id="H2GEb92vyWdNFPAz8gKyTK">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
-                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ColorToDepthImage (Reactive)" />
                 </p:NodeReference>
-                <Pin Id="HBPiP7Ff9rvMmCCT1kk0yT" Name="Input" Kind="StateInputPin" />
-                <Pin Id="LVH9jIQ7jiTPwnKODFIF01" Name="Output" Kind="StateOutputPin" />
-                <Pin Id="Jd4EIpxMzgsLU7fKLjEY7P" Name="Captures" Kind="OutputPin" />
+                <Pin Id="Nq3NrmiXc9xMr8HmH2qkQK" Name="Device" Kind="InputPin" />
+                <Pin Id="NUBRj8OXkDULnECHjMuAMj" Name="Output" Kind="OutputPin" />
               </Node>
             </Canvas>
             <Patch Id="MCfYEbjK7ULOSBh008npDA" Name="Create" />
             <Patch Id="J3C4GqZcOZSLjwMZGKah2u" Name="Update">
-              <Pin Id="VxXFa5zJ6GoQHg7hCOognc" Name="Sensor" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="VxXFa5zJ6GoQHg7hCOognc" Name="Device" Kind="InputPin" Bounds="180,751" />
               <Pin Id="O7q9yYjtgpPMisxfzs642s" Name="Output" Kind="OutputPin" Bounds="104,965" />
             </Patch>
             <ProcessDefinition Id="LlQ8NRSEt3mMQjhL7BYFlr">
@@ -5401,21 +5194,9 @@
             </ProcessDefinition>
             <Link Id="GJkaNcpQKumP0dbgq7IqNC" Ids="VxXFa5zJ6GoQHg7hCOognc,JC4IGovnxeAMLhr4KmvL2c" IsHidden="true" />
             <Link Id="TaVsnxOqdCkNKUaZe4eBiv" Ids="FNfEsrLSwLZMBU9Zix9IeA,O7q9yYjtgpPMisxfzs642s" IsHidden="true" />
-            <Link Id="JhxgyEyrN7JNRnBOLaFJwT" Ids="JC4IGovnxeAMLhr4KmvL2c,IvbylqMY8ePNsdbXYQbmyZ" />
             <Link Id="FvH2Z9z8IyfPaVa8XQ2Nt8" Ids="Lr3REqOnNVbO2YErW38r7E,FNfEsrLSwLZMBU9Zix9IeA" />
-            <Link Id="TrMQPuP88ulOt7p4McBe2b" Ids="CMhuOIZxkNJMoQX8LXUR9P,I85zV97ddtLO0Kwr1jn0y7" IsHidden="true" />
-            <Link Id="FRe59ms6YpHL3IWphIBIlh" Ids="CsdrvaVzkMYMPvxLBEShKY,CHDC5zp4bEzNL3KeQnfb2e" IsHidden="true" />
-            <Link Id="LeillCy7VE3L9efgat7FF4" Ids="OlgvxEHLNkLOIRdpifmWSI,SDj4PQlfxm3OwA3MXB8H6R" />
-            <Link Id="Unjq2VAwevUMIpWy9s0BMZ" Ids="DafavwAtVCgPDP4NttiuMh,MJGyBOtVNSXNB5JjboIvqP" />
-            <Link Id="KkNQ73puDmCPDGH0Ry1Fl5" Ids="I85zV97ddtLO0Kwr1jn0y7,Q6Nu5s19I99LhzoRKjsAyr" />
-            <Link Id="VCSoyxvV8sOPDclLXhuW3c" Ids="ATjTCyn0sQsOgbmRwytxix,CsdrvaVzkMYMPvxLBEShKY" />
-            <Link Id="EK1zuonbc6xPNTczJqWrfT" Ids="AIr5u96yxIqP9pGMxdaf53,MPyJ61bYHHlPNh6IvmjpyD" />
-            <Link Id="Vl1VYDyCYbqPjdCZMqiXL5" Ids="MPyJ61bYHHlPNh6IvmjpyD,AnYJVSwxze9MpKkZznOtdK" />
-            <Link Id="Qt5u9qeTyFGLDOIYdZVO11" Ids="BkB3mlZONjbLLwyFjrFnnh,Bz2Ts5CF5xyPbumVLGMV5Z" IsHidden="true" />
-            <Link Id="RvGIfCEo1YfLKdV2MGOPej" Ids="FICM126UDXoNxcS4JQt0tM,Rq1OuJR6wgqOi8V2RoTWXz" />
-            <Link Id="HqKGlqYW20FLkwa1F4fDWU" Ids="JC4IGovnxeAMLhr4KmvL2c,HBPiP7Ff9rvMmCCT1kk0yT" />
-            <Link Id="MdmwHH6fxD9LsusExuRyEh" Ids="Jd4EIpxMzgsLU7fKLjEY7P,N9sHT2a7suqLi5v1SCjmyh" />
-            <Link Id="Q8MAPzE6AGEQMTfLtnEsau" Ids="N9sHT2a7suqLi5v1SCjmyh,FICM126UDXoNxcS4JQt0tM" />
+            <Link Id="BlgXmJXRCewLhE6uZSC29l" Ids="JC4IGovnxeAMLhr4KmvL2c,Nq3NrmiXc9xMr8HmH2qkQK" />
+            <Link Id="IKv7LvfNz4HMQtlt4ug1aO" Ids="NUBRj8OXkDULnECHjMuAMj,AnYJVSwxze9MpKkZznOtdK" />
           </Patch>
         </Node>
         <!--
@@ -5423,17 +5204,17 @@
     ************************ DepthToColorImage ************************
 
 -->
-        <Node Name="DepthToColorImage" Bounds="716,652" Id="A9U4v1sLcutMI5zg9ih7j6">
+        <Node Name="DepthToColorImage" Bounds="715,652" Id="A9U4v1sLcutMI5zg9ih7j6">
           <p:NodeReference>
             <Choice Kind="ContainerDefinition" Name="Process" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="Jua0sZ41Oy4MhU7tv9ujkD">
             <Canvas Id="Bna6zuXfWetOb0P6R0O8eA" CanvasType="Group">
-              <ControlPoint Id="L9b76T03MQRNLVaEMAnJ9G" Bounds="315,320" />
-              <ControlPoint Id="NXPrVMUKAliNCfySx8r4Mz" Bounds="347,785" />
-              <Node Bounds="345,739,88,19" Id="JYjquUiWXrONEkFxPzI17t">
-                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastSymbolSource="VL.Imaging.vl">
+              <ControlPoint Id="L9b76T03MQRNLVaEMAnJ9G" Bounds="302,320" />
+              <ControlPoint Id="NXPrVMUKAliNCfySx8r4Mz" Bounds="302,567" />
+              <Node Bounds="300,491,88,19" Id="JYjquUiWXrONEkFxPzI17t">
+                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
                 </p:NodeReference>
@@ -5444,93 +5225,18 @@
                 <Pin Id="DRTRF8uXB08LU4FywGY5De" Name="Swap Count" Kind="OutputPin" />
                 <Pin Id="NYj4pznPGFjOUYSqcXA3hY" Name="Drop Count" Kind="OutputPin" />
               </Node>
-              <Node Bounds="301,409,290,309" Id="TqXnnHQHwmoNPAKm0FbBKI">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="HY3yhd8pPICM1jrm37F46L" Name="Force" Kind="InputPin" />
-                <Pin Id="DcR5jbmtXEZOZNrtkhiU9A" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="NaCaOdsJV0HNBxe50O1Ulw" Name="Has Changed" Kind="OutputPin" />
-                <ControlPoint Id="FgNtvI37ysCLLv54Kackcu" Bounds="347,713" Alignment="Bottom">
-                  <p:TypeAnnotation>
-                    <Choice Kind="TypeFlag" Name="Observable" />
-                    <p:TypeArguments>
-                      <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Image" />
-                      </TypeReference>
-                    </p:TypeArguments>
-                  </p:TypeAnnotation>
-                </ControlPoint>
-                <ControlPoint Id="TvOzviD4qqENYviWmYDbPE" Bounds="328,415" Alignment="Top" />
-                <Patch Id="OL7xiK6VSmXPInALR7Qfcy" ManuallySortedPins="true">
-                  <Patch Id="AoBHIwTSKABPLhqqZKXsGE" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="SVqDThSQaZVQHZ87IySRrh" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="353,490,226,182" Id="D6hoPpSBfx3MoWE2WBF4Am">
-                    <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
-                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="ForEach" />
-                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
-                    </p:NodeReference>
-                    <Pin Id="F6iqBsM2O2oPTWjRqCbpCy" Name="Messages" Kind="InputPin" />
-                    <Pin Id="GHSbsu2WciuORezkrmIM1V" Name="Reset" Kind="InputPin" />
-                    <Pin Id="HasxKxD5x2hMKY3SO578fd" Name="Result" Kind="OutputPin" />
-                    <Patch Id="GSrqxT5rdTjPJgjf04EHCT" ManuallySortedPins="true">
-                      <Patch Id="M4K7ipZJ72kQZ8iHfaIEWp" Name="Create" ManuallySortedPins="true" />
-                      <Patch Id="LcN0D0GpTG3NnjVf7X91e0" Name="Update" ManuallySortedPins="true">
-                        <Pin Id="AdP67FwFT1sQJFC1YVjlx1" Name="Input 1" Kind="InputPin" />
-                        <Pin Id="H6QUEmRwFaaMvUdUjFOXQV" Name="Output" Kind="OutputPin" />
-                      </Patch>
-                      <ControlPoint Id="VbWNrpFwhw3NrRbcKzCQyY" Bounds="357,502" />
-                      <ControlPoint Id="SN58ZEHMMFSOFg1XZddcsK" Bounds="366,665" />
-                      <Node Bounds="408,513,86,19" Id="KWa7iTdJNtLMfy5KtT8L8r">
-                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <Choice Kind="ProcessAppFlag" Name="Transformation" />
-                        </p:NodeReference>
-                        <Pin Id="B1Jsx09153xLmWMMZ4bDrg" Name="Device" Kind="InputPin" />
-                        <Pin Id="KJcqJNhs7pcMTceFwhHdFZ" Name="Output" Kind="OutputPin" />
-                      </Node>
-                      <Node Bounds="425,562,142,26" Id="Vpeb1PtLcrTPlmEkmjm62c">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
-                          <PinReference Kind="OutputPin" Name="return" ParameterModifier="return" />
-                          <PinReference Kind="InputPin" Name="Capture" />
-                          <Choice Kind="OperationCallFlag" Name="DepthImageToColorCamera" />
-                        </p:NodeReference>
-                        <Pin Id="G6Pg0LiQWbtN4E8Ca5Nqhl" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="BEbIPyM4MGrO1INnA41XAH" Name="Capture" Kind="InputPin" />
-                        <Pin Id="E6cdkNwRmJwOFnPkX3Cdqn" Name="Output" Kind="StateOutputPin" />
-                        <Pin Id="AR35hLwvaMPPzQGsNGsQgo" Name="Result" Kind="OutputPin" />
-                      </Node>
-                      <Node Bounds="423,619,99,26" Id="FX2IqPYmNIxM6fqP73AOon">
-                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <Choice Kind="OperationCallFlag" Name="AsVLImage" />
-                        </p:NodeReference>
-                        <Pin Id="NsfZPeP7cZyLNjM6OTV1yd" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="JflgY46hFfULrAR2hjyq2C" Name="Result" Kind="OutputPin" />
-                      </Node>
-                    </Patch>
-                  </Node>
-                </Patch>
-              </Node>
-              <Node Bounds="299,359,85,26" Id="JPKwtzi9ov0P6KOGYD7To6">
-                <p:NodeReference>
+              <Node Bounds="300,395,108,19" Id="Kv9fDKyUgmQLCy22nhMglB">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
-                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DepthToColorImage (Reactive)" />
                 </p:NodeReference>
-                <Pin Id="EZkgkyawoLhNTzqoRHuSbQ" Name="Input" Kind="StateInputPin" />
-                <Pin Id="R4xeiw5jmTdLLWUqimwLsu" Name="Output" Kind="StateOutputPin" />
-                <Pin Id="BKawQzouK7hPmixKweOdJC" Name="Captures" Kind="OutputPin" />
+                <Pin Id="JIqsQ1F5pgCOQce9WpuNnS" Name="Device" Kind="InputPin" />
+                <Pin Id="VFdu1wjyABsPBMYs0SYRH8" Name="Output" Kind="OutputPin" />
               </Node>
             </Canvas>
             <Patch Id="K073umtJGq9NKzz25vIjYR" Name="Create" />
             <Patch Id="Fl5g1zspoNtP7evKKlpsay" Name="Update">
-              <Pin Id="DIROqvGaS5EP2muxm5Wuzu" Name="Sensor" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="DIROqvGaS5EP2muxm5Wuzu" Name="Device" Kind="InputPin" Bounds="180,751" />
               <Pin Id="VePXCQKozEeMLGTaS0ISul" Name="Output" Kind="OutputPin" Bounds="104,965" />
             </Patch>
             <ProcessDefinition Id="OJF8iXRq2IiMNcyQ8Thj1X">
@@ -5539,19 +5245,9 @@
             </ProcessDefinition>
             <Link Id="HWpZ7xsyyArLhoeAkoyr8H" Ids="DIROqvGaS5EP2muxm5Wuzu,L9b76T03MQRNLVaEMAnJ9G" IsHidden="true" />
             <Link Id="HWCgM87WhRmLhw3Mxh1ewq" Ids="NXPrVMUKAliNCfySx8r4Mz,VePXCQKozEeMLGTaS0ISul" IsHidden="true" />
-            <Link Id="NYgfcbDIoKmMoA0VEfTcQX" Ids="L9b76T03MQRNLVaEMAnJ9G,B1Jsx09153xLmWMMZ4bDrg" />
             <Link Id="S100OsOBOh6OXcJA4cjoQo" Ids="DiXifDzo12OQZqfXaMnpL3,NXPrVMUKAliNCfySx8r4Mz" />
-            <Link Id="MrUWeVScxehOpcjqa40u7z" Ids="FgNtvI37ysCLLv54Kackcu,OQ1airPHLqfOSMLHG17FAw" />
-            <Link Id="E9gtL3RaTy4ODI2ij56lnt" Ids="L9b76T03MQRNLVaEMAnJ9G,EZkgkyawoLhNTzqoRHuSbQ" />
-            <Link Id="V5N1G3kBGouN2AyohBJJrK" Ids="BKawQzouK7hPmixKweOdJC,TvOzviD4qqENYviWmYDbPE" />
-            <Link Id="GGywpXkT9JWLpkVT6U13vZ" Ids="AdP67FwFT1sQJFC1YVjlx1,VbWNrpFwhw3NrRbcKzCQyY" IsHidden="true" />
-            <Link Id="AFJ3PyNHBfnMv520bTXSez" Ids="SN58ZEHMMFSOFg1XZddcsK,H6QUEmRwFaaMvUdUjFOXQV" IsHidden="true" />
-            <Link Id="Gbm6HQ35YvdMrq4U2TYSXJ" Ids="AR35hLwvaMPPzQGsNGsQgo,NsfZPeP7cZyLNjM6OTV1yd" />
-            <Link Id="G2xHMjSDHxkNgZ44R8mngz" Ids="KJcqJNhs7pcMTceFwhHdFZ,G6Pg0LiQWbtN4E8Ca5Nqhl" />
-            <Link Id="IJNKkPIBk2IMdUhgo82wTZ" Ids="JflgY46hFfULrAR2hjyq2C,SN58ZEHMMFSOFg1XZddcsK" />
-            <Link Id="QcotSeo0HdGNeNtfaVE9g4" Ids="TvOzviD4qqENYviWmYDbPE,F6iqBsM2O2oPTWjRqCbpCy" />
-            <Link Id="UvOb8VLNv7UMKvUxKi8Gjx" Ids="HasxKxD5x2hMKY3SO578fd,FgNtvI37ysCLLv54Kackcu" />
-            <Link Id="TlBC6i2AWaBP88uG9r6Lv8" Ids="VbWNrpFwhw3NrRbcKzCQyY,BEbIPyM4MGrO1INnA41XAH" />
+            <Link Id="Fsz6BSNVYTpOljCjiThm4Q" Ids="L9b76T03MQRNLVaEMAnJ9G,JIqsQ1F5pgCOQce9WpuNnS" />
+            <Link Id="MHTMPHY9Lr5PVJXmdG8so5" Ids="VFdu1wjyABsPBMYs0SYRH8,OQ1airPHLqfOSMLHG17FAw" />
           </Patch>
         </Node>
         <!--
@@ -5560,7 +5256,7 @@
 
 -->
         <Node Name="ClockProvider" Bounds="416,236" Id="GsVXSUAon7aMHZ070kLg10">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ClassDefinition" Name="Class" />
           </p:NodeReference>
           <Patch Id="QP2sg8eX8j4PvJRYVu84hX">
@@ -5570,7 +5266,7 @@
               <ControlPoint Id="IHisFvmy66lMYBdTs5uFgX" Bounds="741,285" />
               <Pad Id="BKfgQmjLJY4OmzkmtVYyVE" SlotId="KJzzueqAzbSN2MFzaiU52e" Bounds="615,333" />
               <Node Bounds="613,300,62,19" Id="VwHTYpWHeNoNeONgSWwRNG">
-                <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                 </p:NodeReference>
@@ -5578,7 +5274,7 @@
                 <Pin Id="MVI9b1bdLf4MZQQzo02SjF" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="519,384,192,336" Id="LdEuV3sCDhmL4TBfN2cGmm">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -5592,30 +5288,32 @@
                   <Patch Id="EyZR2eOHalIP8XeCTJBYiZ" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Vz4PlxfYr02O9LETfuAbF2" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="554,606,79,19" Id="PIiGCKEVZtkOcNwP6ZYg89">
-                    <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="ToObservable (Switch)" />
                     </p:NodeReference>
                     <Pin Id="JGcrvahyaaQLxMuvWTWaNV" Name="Message" Kind="InputPin" />
                     <Pin Id="Fe5N0NW5zhCNFBAYfbvm5v" Name="Send" Kind="InputPin" DefaultValue="True">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="R5SFEZ55mCLOrH1FOD9byL" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="542,465,157,126" Id="OvnyZjVIAiXQdNxbryX8LF">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:NodeReference>
                     <Pin Id="S7SoKPp4JXgOOKSUi86gN9" Name="Condition" Kind="InputPin" />
+                    <ControlPoint Id="MHraqrgQjVIOrZvS16mB4i" Bounds="556,585" Alignment="Bottom" />
+                    <ControlPoint Id="F8TGLHUAcsJLc84UNij2eP" Bounds="556,471" Alignment="Top" />
                     <Patch Id="U4MfnKOBHqrPrr3LqJO8zT" ManuallySortedPins="true">
                       <Patch Id="TGodnsIksrGQS47knUN4UM" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="QjPIMH6Jb7XOCOPQxq3gDC" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="554,551,43,19" Id="A0Dj6GS5cmGQI7S1NLVbKS">
-                        <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                        <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
                           <Choice Kind="OperationCallFlag" Name="Timer" />
@@ -5625,7 +5323,7 @@
                         <Pin Id="CfRGYT0b5JvP72BjliBhdi" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="592,520,95,19" Id="BRnpk4BduxCP0NaXk5yo0b">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="TimeSpan" />
                           <Choice Kind="OperationCallFlag" Name="FromSeconds" />
@@ -5634,12 +5332,12 @@
                         <Pin Id="A9gtwHGpNmgPvT06jbZvvq" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="592,488,25,19" Id="CAhxFR58mFpQBWG8XEftRL">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="/" />
                         </p:NodeReference>
                         <Pin Id="NSMHxVMXHUtMcTfMsa1vzV" Name="Input" Kind="InputPin" DefaultValue="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float64" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -5647,11 +5345,9 @@
                         <Pin Id="UFx9D0IH0euMvqWuZjCUM4" Name="Output" Kind="OutputPin" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="MHraqrgQjVIOrZvS16mB4i" Bounds="556,585" Alignment="Bottom" />
-                    <ControlPoint Id="F8TGLHUAcsJLc84UNij2eP" Bounds="556,471" Alignment="Top" />
                   </Node>
                   <Node Bounds="543,423,25,19" Id="DVPWwDFrUicPCrJXNVGQpr">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;" />
                     </p:NodeReference>
@@ -5662,7 +5358,7 @@
                 </Patch>
               </Node>
               <Node Bounds="613,350,25,19" Id="FCp8fEyMp8cPPzM3Kx3aSz">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="*" />
                 </p:NodeReference>
@@ -5671,7 +5367,7 @@
                 <Pin Id="TtS74cb9cEWLaPL5edEWz3" Name="Output" Kind="OutputPin" />
               </Node>
               <Pad Id="Lf30ObhJwS8LbcUImvADBO" Comment="Frame Rate" Bounds="451,255,35,15" ShowValueBox="true" isIOBox="true" Value="30">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pad>
@@ -5681,12 +5377,12 @@
 
 -->
               <Node Name="UpdateFromPlayback" Bounds="915,361,198,183" Id="VarrL1jO2pfOymn64wvxZo">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
                 <Patch Id="R1Xxp2rlITINwsr0M1Wopa">
                   <Node Bounds="1015,412,86,26" Id="AFZq3t1JNtDNSKD5nu2Kr6">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                       <Choice Kind="OperationCallFlag" Name="GetFrameRate" />
@@ -5699,7 +5395,7 @@
                   <Link Id="SBs4xZotzFILAz71a4YZq5" Ids="MGo8v3SpQBQLscGlu4j9Eu,V7IcQrq9TfaMWomRnWKBda" IsHidden="true" />
                   <Link Id="D1bGqzZC3wyMf7sxyeLA8G" Ids="NoIRxVHZeAJQLvXBgdZ8Ec,OTiibtdRlmYQFotVRDKimW" />
                   <Node Bounds="942,456,78,26" Id="U8cRLSdiMBXN0sTutcvAoj">
-                    <p:NodeReference LastCategoryFullName="KinectAzure.ClockProvider" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ClockProvider" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="ClockProvider" />
                       <Choice Kind="OperationCallFlag" Name="SetFrameRate" />
@@ -5713,7 +5409,7 @@
                   <Link Id="OWkpoBzQ5V2PVf0evqQZvI" Ids="F7M476oRnNGMcmQiVftj5h,GnQCganhLtVLWQQcxARzbD" IsHidden="true" />
                   <Link Id="Ed8V6ogitjnMj9gf6uKmsI" Ids="Gj7cLbdx5ToNzH9M5kexv3,DcC8tTRDxbgNimztFVP8nJ" />
                   <Node Bounds="942,498,65,26" Id="DTLfdCXXg4FQY2FQELe8kU">
-                    <p:NodeReference LastCategoryFullName="KinectAzure.ClockProvider" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.ClockProvider" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="ClockProvider" />
                       <Choice Kind="OperationCallFlag" Name="Update" />
@@ -5727,7 +5423,7 @@
               </Node>
               <Pad Id="OBybNusVTchMGvLuWIsKGx" SlotId="U9PQ6P7uubiOx7pToGK2lw" Bounds="703,344" />
               <Node Bounds="720,314" Id="CeUj0zdm98JPHAWZ3RnOs1">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Abs" />
                 </p:NodeReference>
@@ -5735,21 +5431,12 @@
                 <Pin Id="HzRxbKxE73bM68mpvxJQuN" Name="Output" Kind="OutputPin" />
               </Node>
             </Canvas>
-            <Patch Id="G8GlsB6d4qnQbcwYIHRDWR" Name="Create" ParticipatingElements="IVxYMP4x7mPPcgM1k5QJEb" />
             <Link Id="N1hzNeuhnkUPxIBUACCZNx" Ids="Tv3JT50QwnyNAam9s0ufKN,VNu3A0DTbd2NN7Ak5IhfOk" IsHidden="true" />
             <Link Id="G8CBHtDtbezO3faiJ4uQ9g" Ids="URYK0prvSL5PvAUz77nYEU,C11h0ZRZYuiPSPvAn2g2GW" IsHidden="true" />
-            <Patch Id="NAhcXMgNgD5Pu0bYpKNXUe" Name="Update" />
             <Link Id="HvYuvVDNEVzLyDY3fbHFdM" Ids="Ki616hRvupiNjzHMbKHTVK,IHisFvmy66lMYBdTs5uFgX" IsHidden="true" />
             <Slot Id="KJzzueqAzbSN2MFzaiU52e" Name="Frame Rate" />
             <Link Id="DepvlTcTQWxO4r4V3Rfy2j" Ids="VNu3A0DTbd2NN7Ak5IhfOk,CPhz4KrUNkSQDCIYIsQ2jL" />
             <Link Id="DbSfNDIQAkrP9vVKWnxZog" Ids="BKfgQmjLJY4OmzkmtVYyVE,Uu8aeYUj3wkMHTqDFQrsY4" />
-            <Patch Id="UplPr2SdR28NLl8Tslkcmo" Name="SetFrameRate">
-              <Pin Id="Tv3JT50QwnyNAam9s0ufKN" Name="Frame Rate" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Integer64" />
-                </p:TypeAnnotation>
-              </Pin>
-            </Patch>
             <Link Id="DB0Y3HUxeFCN1AGAJtmife" Ids="MVI9b1bdLf4MZQQzo02SjF,BKfgQmjLJY4OmzkmtVYyVE" />
             <Link Id="UQbfqobdxkEMvelo5CO9kR" Ids="TtS74cb9cEWLaPL5edEWz3,I9tc76KTETZOVgcWNwR3cF" />
             <Link Id="HVXhpXT4nefOnHSm0gsfke" Ids="I9tc76KTETZOVgcWNwR3cF,NNrSR4pdwTLLS9LPSDymbj" />
@@ -5759,16 +5446,6 @@
             <Link Id="IVxYMP4x7mPPcgM1k5QJEb" Ids="Lf30ObhJwS8LbcUImvADBO,BKfgQmjLJY4OmzkmtVYyVE" />
             <Link Id="UwUx06Ok2WgN5pBMEZdFfE" Ids="OBybNusVTchMGvLuWIsKGx,VeoDY8Gp6VvLvk2SxtfCyM" />
             <Slot Id="U9PQ6P7uubiOx7pToGK2lw" Name="Speed" />
-            <Patch Id="JCdXWdftufeNupIzxT2kyT" Name="SetSpeed">
-              <Pin Id="Ki616hRvupiNjzHMbKHTVK" Name="Speed" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="TypeFlag" Name="Float32" />
-                </p:TypeAnnotation>
-              </Pin>
-            </Patch>
-            <Patch Id="SRyq7nV2FHGPMK9WWaD50c" Name="GetClock">
-              <Pin Id="C11h0ZRZYuiPSPvAn2g2GW" Name="Clock" Kind="OutputPin" />
-            </Patch>
             <ProcessDefinition Id="KqBLlUifDYILSeuqQF2TxI" HasStateOut="true">
               <Fragment Id="UjEOgFMg8uaN3Vd5yto9Sk" Patch="G8GlsB6d4qnQbcwYIHRDWR" Enabled="true" />
               <Fragment Id="B2bXs2bNxzlPj6C9iJnko7" Patch="UplPr2SdR28NLl8Tslkcmo" />
@@ -5785,6 +5462,25 @@
             <Link Id="A0FssKsykcBOrQB1x0OyEJ" Ids="CfRGYT0b5JvP72BjliBhdi,MHraqrgQjVIOrZvS16mB4i" />
             <Link Id="C1Nb572TrF9OouexXKoKei" Ids="MHraqrgQjVIOrZvS16mB4i,JGcrvahyaaQLxMuvWTWaNV" />
             <Link Id="E3HPyznD1OfOcHfXk2aUCj" Ids="HzRxbKxE73bM68mpvxJQuN,OBybNusVTchMGvLuWIsKGx" />
+            <Patch Id="G8GlsB6d4qnQbcwYIHRDWR" Name="Create" ParticipatingElements="IVxYMP4x7mPPcgM1k5QJEb" />
+            <Patch Id="NAhcXMgNgD5Pu0bYpKNXUe" Name="Update" />
+            <Patch Id="UplPr2SdR28NLl8Tslkcmo" Name="SetFrameRate">
+              <Pin Id="Tv3JT50QwnyNAam9s0ufKN" Name="Frame Rate" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer64" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <Patch Id="JCdXWdftufeNupIzxT2kyT" Name="SetSpeed">
+              <Pin Id="Ki616hRvupiNjzHMbKHTVK" Name="Speed" Kind="InputPin" DefaultValue="1">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <Patch Id="SRyq7nV2FHGPMK9WWaD50c" Name="GetClock">
+              <Pin Id="C11h0ZRZYuiPSPvAn2g2GW" Name="Clock" Kind="OutputPin" />
+            </Patch>
           </Patch>
         </Node>
         <!--
@@ -5793,7 +5489,7 @@
 
 -->
         <Node Name="WorldToColor" Bounds="442,783" Id="GrSjaV3fhHzOmIWD2CzZn0">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="S1HWRL6NAl8NF26o6k5A8g">
@@ -5802,7 +5498,7 @@
               <ControlPoint Id="JZhwgSgNhanOQJrchqxATt" Bounds="492,410" />
               <ControlPoint Id="PmztI6BFFdMPMoFLm42jUf" Bounds="593,880" />
               <Node Bounds="262,290,82,26" Id="IN6y5609sqMQXvFLeGyHRi">
-                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCalibration" />
                   <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -5812,7 +5508,7 @@
                 <Pin Id="JDQNIAOuC26Mp1STTwgHK4" Name="Calibration" Kind="OutputPin" />
               </Node>
               <Node Bounds="267,345,65,19" Id="DCUswcGUQX4MupzuITQRUt">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                 </p:NodeReference>
@@ -5822,7 +5518,7 @@
                 <Pin Id="GERK2kjCr74Lqk0AwQkqsR" Name="On Data" Kind="OutputPin" />
               </Node>
               <Node Bounds="266,395,58,26" Id="Hwqe1lA5cc1LL27MnxGvR0">
-                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Nullable" />
                   <Choice Kind="OperationCallFlag" Name="HasValue" />
@@ -5832,7 +5528,7 @@
                 <Pin Id="Pm3CVSGxdUpMxtQKMeFNgY" Name="Has Value" Kind="OutputPin" />
               </Node>
               <Node Bounds="365,446,325,396" Id="OscRHXkY1CeQHXjb79aJ00">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -5844,7 +5540,7 @@
                   <Patch Id="JZFTVDgrCZtNTYcNW7C3ve" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="FDpV4KHp5c4PHnpk9UDdKo" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="455,466,223,356" Id="KlUmIQxBBucQTXEzc7qTLO">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                       <FullNameCategoryReference ID="Primitive" />
@@ -5857,7 +5553,7 @@
                       <Patch Id="TDhtdMqdrTKPONquFY939x" Name="Update" ManuallySortedPins="true" />
                       <Patch Id="TSwrDVgnpJRNRIdhsuU0c3" Name="Dispose" ManuallySortedPins="true" />
                       <Node Bounds="467,559,88,26" Id="BP7lkKAmiXlLAkKn5M8QQN">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Calibration" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TransformTo2D" />
                           <PinReference Kind="InputPin" Name="Source Point 3D" />
@@ -5866,7 +5562,7 @@
                         <Pin Id="KCzscTjh2CsNB4hvCTAw75" Name="Source Point 3D" Kind="InputPin" />
                         <Pin Id="D1Hpa96DNdlMPFwE1PhlSD" Name="Source Camera" Kind="InputPin" />
                         <Pin Id="F4o8cTJ2OSzMJXzQkSk36O" Name="Target Camera" Kind="InputPin" DefaultValue="Color">
-                          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                          <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                             <Choice Kind="TypeFlag" Name="CalibrationDeviceType" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -5874,7 +5570,7 @@
                         <Pin Id="V4Ck0dZxDskLdqQ1FEKxb5" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="495,490,75,19" Id="RmVefrZW12YPwRDqi7FLPx">
-                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="Category" Name="AzureKinect" NeedsToBeDirectParent="true">
                             <p:OuterCategoryReference Kind="Category" Name="Devices" NeedsToBeDirectParent="true" />
@@ -5885,7 +5581,7 @@
                         <Pin Id="VPnWpZRN1LIMQ266bHW3Tg" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="550,611,58,26" Id="JmNm9itsYvWQDm3q1TTlyX">
-                        <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="HasValue" />
                         </p:NodeReference>
@@ -5893,20 +5589,20 @@
                         <Pin Id="BUb1gEhyi6xQL9XxJAAYDW" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="KiIRc7jH3V7OADCAqHJxCH" Name="Has Value" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="538,656,128,145" Id="DehshAi2SmhMo5s6U21iZG">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                      <Node Bounds="538,656,128,146" Id="DehshAi2SmhMo5s6U21iZG">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="LWNNGY4f6HkL2Tgic3mnhO" Name="Condition" Kind="InputPin" />
                         <ControlPoint Id="VzGaNTOVpncMgtpO6c5s3W" Bounds="593,796" Alignment="Bottom" />
-                        <ControlPoint Id="TZv6vBYFWEENdntaXFwsYN" Bounds="590,663" Alignment="Top" />
+                        <ControlPoint Id="TZv6vBYFWEENdntaXFwsYN" Bounds="590,662" Alignment="Top" />
                         <Patch Id="UhCOv8DKakBPclLUfMfT5k" ManuallySortedPins="true">
                           <Patch Id="Ji9JCFwasUxMOEuVayGHiZ" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="FMqfH1CLE9IO2USyMpF2NL" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="550,691,46,26" Id="JC5W0vRqK6zMRz2m2rmsmF">
-                            <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Nullable" />
                               <Choice Kind="OperationCallFlag" Name="Value" />
@@ -5916,7 +5612,7 @@
                             <Pin Id="N07QquBl30kMvQFzcXFDiC" Name="Value" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="591,742,63,19" Id="GSHnyRsI0t4OXzqv9fOGG9">
-                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="ToVector2" />
                               <CategoryReference Kind="Category" Name="AzureKinect" NeedsToBeDirectParent="true">
@@ -5931,7 +5627,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="377,493,46,26" Id="A0Lzm79yuj3NnEfXSDuCF4">
-                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Value" />
                       <CategoryReference Kind="ClassType" Name="Nullable" NeedsToBeDirectParent="true" />
@@ -5982,110 +5678,15 @@
     ************************ ColorToDepthImage (Reactive) ************************
 
 -->
-        <Node Name="ColorToDepthImage (Reactive)" Bounds="919,605" Id="Hcm1TC9Rkq8NGHYKJUkcKU">
+        <Node Name="ColorToDepthImage (Reactive)" Bounds="919,603" Id="Hcm1TC9Rkq8NGHYKJUkcKU">
           <p:NodeReference>
             <Choice Kind="ContainerDefinition" Name="Process" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="URSN1BsPqkCMLudk2OyluN">
             <Canvas Id="QCxXNpP1PItQElGfBSMlNj" CanvasType="Group">
-              <ControlPoint Id="Bs3uOpM1KTMOcJiK3MmFcU" Bounds="239,217" />
-              <Node Bounds="156,316,249,309" Id="Nxgl9dR3EsePDRF1SgfyXl">
-                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="NfKpvHAtrnuOEsYoJnkw5x" Name="Force" Kind="InputPin" />
-                <Pin Id="FuMsQlOql42P7zEM67RvVm" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="RKyyNX6pUucMjSBbCs0L5I" Name="Has Changed" Kind="OutputPin" />
-                <ControlPoint Id="SKQ9vBAXimgMqcpHJ9bvhj" Bounds="201,619" Alignment="Bottom">
-                  <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Observable" />
-                    <p:TypeArguments>
-                      <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Image" />
-                      </TypeReference>
-                    </p:TypeArguments>
-                  </p:TypeAnnotation>
-                </ControlPoint>
-                <ControlPoint Id="DLh8EwsiCjZLUt9WLNYxln" Bounds="203,322" Alignment="Top" />
-                <Patch Id="PoGrVpQQhv8LAO40iZCAIP" ManuallySortedPins="true">
-                  <Patch Id="EvAY3hpcgzlMJvjZs5yCs8" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="FVjzfUddjEgMMq7zQPBhdR" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="199,423,194,158" Id="N7ruKiOADQ2NcVaMjmqtZS">
-                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="OperationCallFlag" Name="Select" />
-                      <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
-                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                    </p:NodeReference>
-                    <Pin Id="DF4ulmicMuvLBvnDyACMkS" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="KlRb0ME50EGMvhvnjyNbLC" Name="Output" Kind="StateOutputPin" />
-                    <Patch Id="PK70RjgFnIBNkB0U7ycPvC" Name="Selector" ManuallySortedPins="true">
-                      <ControlPoint Id="O28KKRw2ro2Nl4AcPVf2sg" Bounds="203,431" />
-                      <ControlPoint Id="GLZtMQAuQQfN9TyBQA0lyC" Bounds="239,574" />
-                      <Node Bounds="239,456,142,26" Id="LwvNWfok8YLMSLraWQQITW">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
-                          <Choice Kind="OperationCallFlag" Name="ColorImageToDepthCamera" />
-                          <PinReference Kind="OutputPin" Name="return" ParameterModifier="return" />
-                          <PinReference Kind="InputPin" Name="Capture" />
-                        </p:NodeReference>
-                        <Pin Id="CsYrODCc2vuLgETC1fM4Xr" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="DMo0XxxKriFPk3Bz2VGue6" Name="Capture" Kind="InputPin" />
-                        <Pin Id="S01aSPwleeaQEARjXfT0GT" Name="Output" Kind="StateOutputPin" />
-                        <Pin Id="PePmEdtWlh0Ln6rF0UKxyw" Name="Result" Kind="OutputPin" />
-                      </Node>
-                      <Node Bounds="237,513,99,26" Id="EteruSUZK5ZNUZUvYkgP3O">
-                        <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
-                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <Choice Kind="OperationCallFlag" Name="AsVLImage" />
-                        </p:NodeReference>
-                        <Pin Id="L8QRdTkcu9POTlLrfgg3s7" Name="Input" Kind="StateInputPin" />
-                        <Pin Id="KzJvO64mqKiL5hUCtaSXM3" Name="Result" Kind="OutputPin" />
-                      </Node>
-                      <ControlPoint Id="MtC81R5U9NbMGbcl33yGgV" Bounds="332,436" />
-                      <Pin Id="SOrKEzwgntnPrUZFJgQpYK" Name="Input 1" Kind="InputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
-                          <Choice Kind="TypeFlag" Name="Capture" />
-                          <FullNameCategoryReference ID="Devices.AzureKinect" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="EYXDFMZdosXLYM8J0nlbJQ" Name="Input 2" Kind="InputPin" />
-                      <Pin Id="O8RnBvcKi7ePQ0SsFYpPOu" Name="Result" Kind="OutputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="Image" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                    </Patch>
-                  </Node>
-                  <Node Bounds="237,343,86,19" Id="TY3IfSiIYCRQS643rygVHk">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Transformation" />
-                    </p:NodeReference>
-                    <Pin Id="VPlTiV3yvRqLkjAYuxLnoj" Name="Device" Kind="InputPin" />
-                    <Pin Id="C52TkWM6LWfO24Zxujdx6k" Name="Output" Kind="OutputPin" />
-                  </Node>
-                  <Pad Id="Fd0dzQMM3PxQWFjkRnW5AF" Bounds="203,387">
-                    <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Observable" />
-                      <p:TypeArguments>
-                        <TypeReference>
-                          <Choice Kind="TypeFlag" Name="Capture" />
-                          <FullNameCategoryReference ID="Devices.AzureKinect" />
-                        </TypeReference>
-                      </p:TypeArguments>
-                    </p:TypeAnnotation>
-                    <p:ValueBoxSettings>
-                      <p:maxvisiblechars p:Type="Int32">44444</p:maxvisiblechars>
-                      <p:showvalue p:Type="Boolean">false</p:showvalue>
-                    </p:ValueBoxSettings>
-                  </Pad>
-                </Patch>
-              </Node>
-              <Node Bounds="121,262,85,26" Id="SsX7rMu5ZtfODme91Fndp9">
+              <ControlPoint Id="Bs3uOpM1KTMOcJiK3MmFcU" Bounds="210,172" />
+              <Node Bounds="123,217,85,26" Id="SsX7rMu5ZtfODme91Fndp9">
                 <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetCaptures" />
@@ -6095,11 +5696,45 @@
                 <Pin Id="OZMxaoROE4GMAtUgFYp858" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="I0fSkMFrwUwOwEYIBeefdF" Name="Captures" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="QeO9CiFQNGVO7PFJyNSnHR" Bounds="201,642" />
+              <ControlPoint Id="QeO9CiFQNGVO7PFJyNSnHR" Bounds="203,459" />
+              <Node Bounds="324,228,86,19" Id="TY3IfSiIYCRQS643rygVHk">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Transformation" />
+                </p:NodeReference>
+                <Pin Id="VPlTiV3yvRqLkjAYuxLnoj" Name="Device" Kind="InputPin" />
+                <Pin Id="C52TkWM6LWfO24Zxujdx6k" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="189,281,151,86" Id="VYuB4418Z5nLnlh5wpBpup">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="BVvOc026gj9MqsXyjG4WjT" Name="Force" Kind="InputPin" />
+                <Pin Id="JKCu7j0YE3HNwsPhoKxowq" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="BM7hRPWGLMrMrxnc0ghD4u" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="DFEaIL6M0jfPbRRcOnpQyW" ManuallySortedPins="true">
+                  <Patch Id="SwLNy4l7OrvLaWdLB7jRxE" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="OqUvK30SCKEO93JALrFmT9" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="201,313,127,26" Id="PPGnuzzXTQLQGyMOnMgmgv">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectColorDepthImages" />
+                    </p:NodeReference>
+                    <Pin Id="F8jbYbbfuPYMdzMNsUqIQ3" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="ReSLGBWWodUO5fH2HsumGY" Name="Transformation" Kind="InputPin" />
+                    <Pin Id="FDH5XpLZW5ZLP0a2Hpmhjd" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="DCybf9umF1TPAESw1hxWFI" Bounds="204,287" Alignment="Top" />
+                <ControlPoint Id="IZF7Gp2EG6AN5zEuxRVZUK" Bounds="202,361" Alignment="Bottom" />
+                <ControlPoint Id="SmK3NZYKCOHN90i1cfqiaw" Bounds="321,287" Alignment="Top" />
+              </Node>
             </Canvas>
             <Patch Id="RhpRmPDLEmROhI4jzV02V2" Name="Create" />
             <Patch Id="CNKq6fh3FiBPHsYZ3QIP4r" Name="Update">
-              <Pin Id="GD0m8sgdDPGO52lmVG2AeF" Name="Sensor" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="GD0m8sgdDPGO52lmVG2AeF" Name="Device" Kind="InputPin" Bounds="180,751" />
               <Pin Id="EIGVZ5iUgjuOPs6rVgZNms" Name="Output" Kind="OutputPin" Bounds="204,642" />
             </Patch>
             <ProcessDefinition Id="LFsNy1wAGYCOn9PiI3Tfhk">
@@ -6108,20 +5743,324 @@
             </ProcessDefinition>
             <Link Id="PZqOflm6MWYLy6d3RWascj" Ids="GD0m8sgdDPGO52lmVG2AeF,Bs3uOpM1KTMOcJiK3MmFcU" IsHidden="true" />
             <Link Id="A1V62W9OKIPMuDpuN5IF7Y" Ids="Bs3uOpM1KTMOcJiK3MmFcU,VPlTiV3yvRqLkjAYuxLnoj" />
-            <Link Id="Vpr2A748RHYMJRJiowF3aN" Ids="SOrKEzwgntnPrUZFJgQpYK,O28KKRw2ro2Nl4AcPVf2sg" IsHidden="true" />
-            <Link Id="JkPt2gaoajELRnDvDKY5lg" Ids="GLZtMQAuQQfN9TyBQA0lyC,O8RnBvcKi7ePQ0SsFYpPOu" IsHidden="true" />
-            <Link Id="V6etPXgXFrlPlXRJbSR639" Ids="PePmEdtWlh0Ln6rF0UKxyw,L8QRdTkcu9POTlLrfgg3s7" />
-            <Link Id="Pke8CsjeDQZOVu8XYb2XrC" Ids="C52TkWM6LWfO24Zxujdx6k,CsYrODCc2vuLgETC1fM4Xr" />
-            <Link Id="NL5DS7AftDxN68FQt2G4yM" Ids="O28KKRw2ro2Nl4AcPVf2sg,DMo0XxxKriFPk3Bz2VGue6" />
-            <Link Id="RasivZzsxAXPyvJS4EOAgO" Ids="KzJvO64mqKiL5hUCtaSXM3,GLZtMQAuQQfN9TyBQA0lyC" />
-            <Link Id="OqjdnQIX5R4OK1LIWYreFH" Ids="KlRb0ME50EGMvhvnjyNbLC,SKQ9vBAXimgMqcpHJ9bvhj" />
-            <Link Id="N0ppyFkkuY7POx4gKDxDUu" Ids="EYXDFMZdosXLYM8J0nlbJQ,MtC81R5U9NbMGbcl33yGgV" IsHidden="true" />
-            <Link Id="T29sY2f0rASNtfhPmEqKkT" Ids="Fd0dzQMM3PxQWFjkRnW5AF,DF4ulmicMuvLBvnDyACMkS" />
             <Link Id="QjcvQivGFVcPvbImJBMzGJ" Ids="Bs3uOpM1KTMOcJiK3MmFcU,JNkEhNP78bUQK1GS1TtN2K" />
-            <Link Id="QbD310UAxc3LgcMq1yaQtF" Ids="I0fSkMFrwUwOwEYIBeefdF,DLh8EwsiCjZLUt9WLNYxln" />
-            <Link Id="ODqr5ypjFudMiQSkWyOVR5" Ids="DLh8EwsiCjZLUt9WLNYxln,Fd0dzQMM3PxQWFjkRnW5AF" />
-            <Link Id="AF4dC6TbiCwPJBGu7G6ABR" Ids="SKQ9vBAXimgMqcpHJ9bvhj,QeO9CiFQNGVO7PFJyNSnHR" />
             <Link Id="RnRiIdcA5qePguL22yc5N3" Ids="QeO9CiFQNGVO7PFJyNSnHR,EIGVZ5iUgjuOPs6rVgZNms" IsHidden="true" />
+            <Link Id="P2BELMNZqN4PjTsn02S8Lk" Ids="I0fSkMFrwUwOwEYIBeefdF,DCybf9umF1TPAESw1hxWFI" />
+            <Link Id="Ax37hgngjjXOGh5ApJuvPo" Ids="DCybf9umF1TPAESw1hxWFI,F8jbYbbfuPYMdzMNsUqIQ3" />
+            <Link Id="FiwBlG23pMYOf9fip5GqAw" Ids="FDH5XpLZW5ZLP0a2Hpmhjd,IZF7Gp2EG6AN5zEuxRVZUK" />
+            <Link Id="FIOmjhWDG7BLVI0ssZ6Kzl" Ids="IZF7Gp2EG6AN5zEuxRVZUK,QeO9CiFQNGVO7PFJyNSnHR" />
+            <Link Id="OqqoCfwAohIMsuQJ2Abowh" Ids="C52TkWM6LWfO24Zxujdx6k,SmK3NZYKCOHN90i1cfqiaw" />
+            <Link Id="V7SiCpZrBj2QA1SfbaWgKu" Ids="SmK3NZYKCOHN90i1cfqiaw,ReSLGBWWodUO5fH2HsumGY" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ DepthToColorImage (Reactive) ************************
+
+-->
+        <Node Name="DepthToColorImage (Reactive)" Bounds="918,652" Id="LvnIyBcmW97OuwCqyXExF0">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" Name="Process" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="MSyqEXgk9R4OHgshobstrw">
+            <Canvas Id="VAUHLK0eULAPV6FqG6vtJj" CanvasType="Group">
+              <ControlPoint Id="A36BrBHkMCrNdbmPEFjF9f" Bounds="358,257" />
+              <ControlPoint Id="Cjm6EUA2FWONXbLRrWbdS1" Bounds="344,497" />
+              <Node Bounds="264,304,85,26" Id="H67BZwwjRBWNzAsSKcLYT0">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
+                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="Sflx0jDaxxlPc5JmKT14AB" Name="Input" Kind="StateInputPin" />
+                <Pin Id="DAHUmAk0q7yPWGHQIff5k7" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="QqI5UPjKfJWMRTvX94rDpK" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="466,303,86,19" Id="BhCEpzR13ZQP7wFAacnnaT">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Transformation" />
+                </p:NodeReference>
+                <Pin Id="Mwca3xzreWJOZZLFR3F4aj" Name="Device" Kind="InputPin" />
+                <Pin Id="RgggcULr6bDPCIHKxXfoJS" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="330,375,151,86" Id="VXsYKo4odEWNYOGOW9jZS3">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="RhyyIc2pnVFNp6Kzh7tBky" Name="Force" Kind="InputPin" />
+                <Pin Id="JLytwvXJRE8PBOLyp1D1vX" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="I3S2T6yiNzqQLnUntmjvpf" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="Pq6hAiwAsFcMPWJxDslVoW" ManuallySortedPins="true">
+                  <Patch Id="C3eRNh7mx7VPaQSlTKXFs6" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="KMtcaUk40QZPlypn2RYOvc" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="342,407,127,26" Id="E91gmD4N72PN0eylCkxkoO">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectDepthColorImages" />
+                    </p:NodeReference>
+                    <Pin Id="QGm8FW3x3UlMo4LzbMWFpG" Name="Input" Kind="InputPin" />
+                    <Pin Id="LKgNsAv7SOKNffxFnvTtOM" Name="Transformation" Kind="InputPin" />
+                    <Pin Id="T4DKIZPQJYIPWD3spPoPfN" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="E4iNYzfz35gPoSgcTqyzwv" Bounds="347,381" Alignment="Top" />
+                <ControlPoint Id="KUXMwy0i7vMPKbAJfTOEyX" Bounds="346,455" Alignment="Bottom" />
+                <ControlPoint Id="S0SbddDqSINPpSnNJTQ8gV" Bounds="466,381" Alignment="Top" />
+              </Node>
+            </Canvas>
+            <Patch Id="JAaq3kTBq6kN8R6tTiBCmB" Name="Create" />
+            <Patch Id="AtPlRMKEs9UOmlmwZYUGpt" Name="Update">
+              <Pin Id="IMQnAkSNs9YMDhMv2CQhn4" Name="Device" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="HFhVEOfVZT7Oc4wxHsVSPg" Name="Output" Kind="OutputPin" Bounds="104,965" />
+            </Patch>
+            <ProcessDefinition Id="P66SimrBkuzPDW4DLaaRbo">
+              <Fragment Id="A2yP0Vqf7LoM9j7SqRpFYJ" Patch="JAaq3kTBq6kN8R6tTiBCmB" Enabled="true" />
+              <Fragment Id="NGFpDQvQbhsPG6WnNgA3TX" Patch="AtPlRMKEs9UOmlmwZYUGpt" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="VMMzbMgpAX4Nf4aFMZ0eaz" Ids="IMQnAkSNs9YMDhMv2CQhn4,A36BrBHkMCrNdbmPEFjF9f" IsHidden="true" />
+            <Link Id="CX8TjoxmW9OOoTCUGuYjBq" Ids="Cjm6EUA2FWONXbLRrWbdS1,HFhVEOfVZT7Oc4wxHsVSPg" IsHidden="true" />
+            <Link Id="GvDydBuFg1ZPhhLMGLMZLy" Ids="A36BrBHkMCrNdbmPEFjF9f,Mwca3xzreWJOZZLFR3F4aj" />
+            <Link Id="ROJZjAxe1Q6QHzQeMwCTj7" Ids="A36BrBHkMCrNdbmPEFjF9f,Sflx0jDaxxlPc5JmKT14AB" />
+            <Link Id="T4Q5hedwl3OO1bwaY57pO4" Ids="QqI5UPjKfJWMRTvX94rDpK,E4iNYzfz35gPoSgcTqyzwv" />
+            <Link Id="CimWbaNxQh6OwBY8E53LQj" Ids="E4iNYzfz35gPoSgcTqyzwv,QGm8FW3x3UlMo4LzbMWFpG" />
+            <Link Id="E0xjSjWadjtNaahA68o9pX" Ids="T4DKIZPQJYIPWD3spPoPfN,KUXMwy0i7vMPKbAJfTOEyX" />
+            <Link Id="IDnlw1wAw4dOpS4megeGWy" Ids="KUXMwy0i7vMPKbAJfTOEyX,Cjm6EUA2FWONXbLRrWbdS1" />
+            <Link Id="EdGnbQsSYetNVnGaxig8Dy" Ids="RgggcULr6bDPCIHKxXfoJS,S0SbddDqSINPpSnNJTQ8gV" />
+            <Link Id="JE8HkbkgBP6POT59oT7Csx" Ids="S0SbddDqSINPpSnNJTQ8gV,LKgNsAv7SOKNffxFnvTtOM" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ PointCloudImage16 ************************
+
+-->
+        <Node Name="PointCloudImage16" Bounds="715,766" Id="UPkxgg0eLqnNCH9frnJnJn">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" Name="Process" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="LIJ1nZv2iWGPbQtD3bBS7A">
+            <Canvas Id="VVPGVacgy0pLK1IuRbadd7" CanvasType="Group">
+              <ControlPoint Id="H5WHR6PCSnwQS4PxF1usEo" Bounds="337,275" />
+              <ControlPoint Id="M2RJKzINk99NUqzOYLh9aL" Bounds="337,547" />
+              <Node Bounds="335,471,88,19" Id="OJmLG8E87rLOZuObTDmcC5">
+                <p:NodeReference LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="HoldLatestCopy" />
+                </p:NodeReference>
+                <Pin Id="JdIg7GD17PqLT2WHmnQjhA" Name="Async Notifications" Kind="InputPin" />
+                <Pin Id="VU1EVTj5Z4QPDnOjrEKWgp" Name="Timeout" Kind="InputPin" />
+                <Pin Id="P03jQzTRFSMMSRf6uHKJaZ" Name="Reset" Kind="InputPin" />
+                <Pin Id="SRWmTf1KNViOvdMhoXy3bj" Name="Result" Kind="OutputPin" />
+                <Pin Id="Cqwk6RZ8UxLLwMhTDfxBkE" Name="Swap Count" Kind="OutputPin" />
+                <Pin Id="TbQzIZdDfC8NUdSMPU5NSS" Name="Drop Count" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="HxspAWeMCQkLNsENQQsJZl" Bounds="437,275" />
+              <Node Bounds="335,375,94,19" Id="VolIknnwa0xOREbNbnd2li">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="PointCloudImage16 (Reactive)" />
+                </p:NodeReference>
+                <Pin Id="KbbwzdrVpnIL4S9506y3FP" Name="Device" Kind="InputPin" />
+                <Pin Id="LX2Z3qcESSHLpM2P895nrB" Name="Scaling" Kind="InputPin" />
+                <Pin Id="I6xbMuQU1zAOoYKR51c8N2" Name="Output" Kind="OutputPin" />
+              </Node>
+            </Canvas>
+            <Patch Id="I5ZkdXZpE4CPHxC2rSaqkR" Name="Create" />
+            <Patch Id="T5pOOZV327pQWcdxuMSyDX" Name="Update">
+              <Pin Id="GT18LpeEp2qPy7w8Dakk9B" Name="Device" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="BK72QF6AgHUQYON8rQI8EK" Name="Scaling" Kind="InputPin" Bounds="619,293" DefaultValue="0.001" />
+              <Pin Id="Fvytn7eNYbCOeCUT91sZ96" Name="Output" Kind="OutputPin" Bounds="104,965" />
+            </Patch>
+            <ProcessDefinition Id="N8jeIcSVOt1OFnv6FmXHba">
+              <Fragment Id="IirvbJX3dtTLGtxlmJg5yj" Patch="I5ZkdXZpE4CPHxC2rSaqkR" Enabled="true" />
+              <Fragment Id="TdWYPGJXN6wLfatncA6HcY" Patch="T5pOOZV327pQWcdxuMSyDX" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="JrXj5zv8ndyPSMBLPfh8k7" Ids="GT18LpeEp2qPy7w8Dakk9B,H5WHR6PCSnwQS4PxF1usEo" IsHidden="true" />
+            <Link Id="F6NxSplskYWL8p02rNqg8T" Ids="M2RJKzINk99NUqzOYLh9aL,Fvytn7eNYbCOeCUT91sZ96" IsHidden="true" />
+            <Link Id="Qk1NsdqIsBXMxPizk3FiH7" Ids="BK72QF6AgHUQYON8rQI8EK,HxspAWeMCQkLNsENQQsJZl" IsHidden="true" />
+            <Link Id="LtI1WwVN7rFPiXONvAlUcg" Ids="SRWmTf1KNViOvdMhoXy3bj,M2RJKzINk99NUqzOYLh9aL" />
+            <Link Id="KhwMdCPzJLlL6B89EOrtqf" Ids="I6xbMuQU1zAOoYKR51c8N2,JdIg7GD17PqLT2WHmnQjhA" />
+            <Link Id="CqhbSOTM7FUNkgC8aCvQCR" Ids="H5WHR6PCSnwQS4PxF1usEo,KbbwzdrVpnIL4S9506y3FP" />
+            <Link Id="KqnbSqjTfvYOgyUIueICXe" Ids="HxspAWeMCQkLNsENQQsJZl,LX2Z3qcESSHLpM2P895nrB" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ PointCloudImage (Reactive) ************************
+
+-->
+        <Node Name="PointCloudImage (Reactive)" Bounds="925,725" Id="M1NXL4msjWlPkASFZ1vCf2">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" Name="Process" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="Qd6zSg5hMvwQc7GlsHDsAL">
+            <Canvas Id="K2mjGiRlfArM9mQo33pXd8" CanvasType="Group">
+              <ControlPoint Id="DwzioJYx3z1Mgigo6aZew4" Bounds="336,275" />
+              <ControlPoint Id="KOmZVpUWbXhPbGsO5Y4wrU" Bounds="414,688" />
+              <Node Bounds="334,403,83,26" Id="DFAloIeMZYRMtBGHzV3Q0f">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
+                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="DwTTTOjaqwnLw6h5DxdC3M" Name="Input" Kind="StateInputPin" />
+                <Pin Id="GSdZsxFBfyHNmB6qd0ttvT" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="Iespx5V00NAPl4cjC2AA4r" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="JXqZs3PgcRvMAAgT4FeDgx" Bounds="617,275" />
+              <Node Bounds="470,400,86,19" Id="LusH7HtwhY9MkDggIWSMdi">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Transformation" />
+                </p:NodeReference>
+                <Pin Id="BFa8WBhR3SgP4cxEec09P4" Name="Device" Kind="InputPin" />
+                <Pin Id="MrtUkXvJfITPo31Is8ALk7" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="400,463,232,95" Id="IL3nEDoiuhDOBnYa70C41Y">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="LidlxZIu70WLucJyYDo52H" Name="Force" Kind="InputPin" />
+                <Pin Id="GTvtr548NBVPiV7C0XX1Nv" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="Jwz4r4gQApbLMW7wjeqRs3" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="AbLopJY1A7BNkwHR1POtBS" ManuallySortedPins="true">
+                  <Patch Id="EjQkEaGjov2MszDqarG0pr" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="Ufd4L0NH6WsPGv81VnX4Wi" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="412,500,120,26" Id="CfegiTL29AvNUu0YvQ39fp">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectPointCloudImage" />
+                    </p:NodeReference>
+                    <Pin Id="NUbK9JqmSOIQcomtPsANBt" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="J2koarZsl3XP7LbuwhlTfE" Name="Transformation" Kind="InputPin" />
+                    <Pin Id="JPh9X64U8KMMBB5gFqxh10" Name="Scaling" Kind="InputPin" />
+                    <Pin Id="BWed0BDFarONVOTRhtBzTl" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="TZL6w4Qcwu9PHdtYouymUT" Bounds="414,469" Alignment="Top" />
+                <ControlPoint Id="LXZfRp5toceN7SUdyGYc4l" Bounds="414,552" Alignment="Bottom" />
+                <ControlPoint Id="A838stg1IarOlmC1OQx8Ru" Bounds="617,469" Alignment="Top" />
+                <ControlPoint Id="S9bUHClzM5NNbbUtFPrIj5" Bounds="471,469" Alignment="Top" />
+              </Node>
+            </Canvas>
+            <Patch Id="QUEilGNgZjXMnMbYkBTEUf" Name="Create" />
+            <Patch Id="UfxScXRJ5WjQW7YALcRoSn" Name="Update">
+              <Pin Id="NCFit1QjPOlP1yDpRftv21" Name="Device" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="BkOtol8qviAPBNtJfOH9r5" Name="Scaling" Kind="InputPin" Bounds="619,293" DefaultValue="0.001" />
+              <Pin Id="KNqzWXP5mOEPANTFFQCBBC" Name="Output" Kind="OutputPin" Bounds="104,965" />
+            </Patch>
+            <ProcessDefinition Id="TRi3DxDkHMQLRu5TgYUDca">
+              <Fragment Id="KVzLTcKjEDvMdNYL7pwDbq" Patch="QUEilGNgZjXMnMbYkBTEUf" Enabled="true" />
+              <Fragment Id="B33UKqFgQOZPPQJ9hyblwC" Patch="UfxScXRJ5WjQW7YALcRoSn" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="H9M0iQfKbTgM6hL9W5DfZu" Ids="DwzioJYx3z1Mgigo6aZew4,DwTTTOjaqwnLw6h5DxdC3M" />
+            <Link Id="FFiOnwzgjgHM7FDCBPFfz6" Ids="NCFit1QjPOlP1yDpRftv21,DwzioJYx3z1Mgigo6aZew4" IsHidden="true" />
+            <Link Id="Q5piTr3UCANPukhAoKRhH6" Ids="KOmZVpUWbXhPbGsO5Y4wrU,KNqzWXP5mOEPANTFFQCBBC" IsHidden="true" />
+            <Link Id="Ve5QhF8fSbULlrJFnVHaJI" Ids="DwzioJYx3z1Mgigo6aZew4,BFa8WBhR3SgP4cxEec09P4" />
+            <Link Id="PfhKMCA7qHJOm40gK1lwUn" Ids="BkOtol8qviAPBNtJfOH9r5,JXqZs3PgcRvMAAgT4FeDgx" IsHidden="true" />
+            <Link Id="Suev6A1Zb26Pjq6DmPQyOa" Ids="Iespx5V00NAPl4cjC2AA4r,TZL6w4Qcwu9PHdtYouymUT" />
+            <Link Id="TrVVU909x7BMqdMkGGq7oZ" Ids="TZL6w4Qcwu9PHdtYouymUT,NUbK9JqmSOIQcomtPsANBt" />
+            <Link Id="GNcqp8JhQLcM3yzI36uF2b" Ids="BWed0BDFarONVOTRhtBzTl,LXZfRp5toceN7SUdyGYc4l" />
+            <Link Id="RyaSdEembitL2nD0MwNEe9" Ids="JXqZs3PgcRvMAAgT4FeDgx,A838stg1IarOlmC1OQx8Ru" />
+            <Link Id="GXyo4Bt4hw7NQ4HR6BY32U" Ids="A838stg1IarOlmC1OQx8Ru,JPh9X64U8KMMBB5gFqxh10" />
+            <Link Id="DyVQVT9ToOlPZ8m0wXuP8n" Ids="MrtUkXvJfITPo31Is8ALk7,S9bUHClzM5NNbbUtFPrIj5" />
+            <Link Id="VgilFF4I89uQL0dQ68I1SZ" Ids="S9bUHClzM5NNbbUtFPrIj5,J2koarZsl3XP7LbuwhlTfE" />
+            <Link Id="LDzI6WtlNfsNFiZoigBT2E" Ids="LXZfRp5toceN7SUdyGYc4l,KOmZVpUWbXhPbGsO5Y4wrU" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ PointCloudImage16 (Reactive) ************************
+
+-->
+        <Node Name="PointCloudImage16 (Reactive)" Bounds="926,772" Id="NY58GXAAkxyLajQn429eMU">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" Name="Process" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="UFC6fH5U3rrOiXzzbA9jUq">
+            <Canvas Id="VsCpEj3w67HPH1q1aHURe1" CanvasType="Group">
+              <ControlPoint Id="LQcbmlQOGVnLijbXkhKm5G" Bounds="337,275" />
+              <ControlPoint Id="KvioOup9iqqNZkuYuXtiMV" Bounds="415,652" />
+              <Node Bounds="335,403,83,26" Id="MYYBPoRe6IVNUadOtm8Rm1">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetCaptures" />
+                  <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="UPn0x3jQtzlPGLUw2YV24p" Name="Input" Kind="StateInputPin" />
+                <Pin Id="IbYVdlo9KWSON7ulr6WEcy" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="Fx3w1Pk8r1NMYtQvscgIsz" Name="Captures" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="OmD2m60mKLhMFlTyNI0FKU" Bounds="617,275" />
+              <Node Bounds="476,404,86,19" Id="MYgXAyt9y7JLcErG4dNQ6S">
+                <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastDependency="VL.Devices.AzureKinect.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Transformation" />
+                </p:NodeReference>
+                <Pin Id="CyUQRfLSVvQM1I8cxKxPgc" Name="Device" Kind="InputPin" />
+                <Pin Id="BGdOQgGVD30NNUVRc9YbT6" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="401,465,231,99" Id="AbxtGp1CMxXORViWVHFfMJ">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="SeEj0Fg082DOmKybSulkvD" Name="Force" Kind="InputPin" />
+                <Pin Id="HU5eTPeBuDhLJRVUa0aOMy" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="V3pFv1ihzwrN9O4Jzgc3Tr" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="UNvBiyUMttRLabTHTG9PiG" ManuallySortedPins="true">
+                  <Patch Id="UxWXM6r4J91N7KHy4VTtjY" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="Ju8zzqlLtTHMAypB6dMqP4" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="413,507,132,26" Id="KVNpoi3AwgcMil7eRXfIHV">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SelectPointCloudImage16" />
+                    </p:NodeReference>
+                    <Pin Id="RWDEhW1pDwQNmzinv22hMj" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="SCHq8k8OuHGMxfFn21wg2k" Name="Transformation" Kind="InputPin" />
+                    <Pin Id="BX4r5NjCPsjOVk1ddSi2J1" Name="Scaling" Kind="InputPin" />
+                    <Pin Id="GV1un99iT2BMEJOYVEgdtp" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="HndcgrYOnILMRyTbFiKZde" Bounds="415,471" Alignment="Top" />
+                <ControlPoint Id="P6CzxIzFPytNcyX3lJyvQL" Bounds="415,558" Alignment="Bottom" />
+                <ControlPoint Id="VkTNrWslZoaPYhEMqCyv0G" Bounds="617,471" Alignment="Top" />
+                <ControlPoint Id="D8BIJSAIkUiPV9T5F3I9Ss" Bounds="478,471" Alignment="Top" />
+              </Node>
+            </Canvas>
+            <Patch Id="CWsM0BPuhFwN1MqXsgXWvW" Name="Create" />
+            <Patch Id="OCjZuXh4USsMmTlxwTI75c" Name="Update">
+              <Pin Id="H1aXrqTnJJBP29GJLaMfyE" Name="Device" Kind="InputPin" Bounds="180,751" />
+              <Pin Id="TcvrScC9i6CMn7EMhrY8Cn" Name="Scaling" Kind="InputPin" Bounds="619,293" DefaultValue="0.001" />
+              <Pin Id="SgH2I7t76kTNSd6K3dxxey" Name="Output" Kind="OutputPin" Bounds="104,965" />
+            </Patch>
+            <ProcessDefinition Id="F53Zh8gbY7xOR7Dx9XLTG1">
+              <Fragment Id="FdWeD8gKzjZOZ2qsmplrK2" Patch="CWsM0BPuhFwN1MqXsgXWvW" Enabled="true" />
+              <Fragment Id="FWI5LDGvvf6LOXIDmGsQUa" Patch="OCjZuXh4USsMmTlxwTI75c" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="UOOzkDq2H6KL1gS2rqT39A" Ids="LQcbmlQOGVnLijbXkhKm5G,UPn0x3jQtzlPGLUw2YV24p" />
+            <Link Id="LIJi7FFaHz4O6XdPPTeOvP" Ids="H1aXrqTnJJBP29GJLaMfyE,LQcbmlQOGVnLijbXkhKm5G" IsHidden="true" />
+            <Link Id="CnLCMkvklzDPT0NUm1rtje" Ids="KvioOup9iqqNZkuYuXtiMV,SgH2I7t76kTNSd6K3dxxey" IsHidden="true" />
+            <Link Id="QtEjOVsuhZKNBfwUHqZstE" Ids="LQcbmlQOGVnLijbXkhKm5G,CyUQRfLSVvQM1I8cxKxPgc" />
+            <Link Id="AJIkYUmUULRLvn5x3lFPYP" Ids="TcvrScC9i6CMn7EMhrY8Cn,OmD2m60mKLhMFlTyNI0FKU" IsHidden="true" />
+            <Link Id="RfliMVV4ynZMAYnPp2W1c6" Ids="Fx3w1Pk8r1NMYtQvscgIsz,HndcgrYOnILMRyTbFiKZde" />
+            <Link Id="PVVwxQcJO3DLXs7BzPOv6r" Ids="HndcgrYOnILMRyTbFiKZde,RWDEhW1pDwQNmzinv22hMj" />
+            <Link Id="VGIgTmJK1RTMBb6DeZYAK4" Ids="GV1un99iT2BMEJOYVEgdtp,P6CzxIzFPytNcyX3lJyvQL" />
+            <Link Id="UYpRkZZG6K6MCGnQ0HkWEZ" Ids="OmD2m60mKLhMFlTyNI0FKU,VkTNrWslZoaPYhEMqCyv0G" />
+            <Link Id="LIZ3m0a8Jo4PGYJ7mU9cfz" Ids="VkTNrWslZoaPYhEMqCyv0G,BX4r5NjCPsjOVk1ddSi2J1" />
+            <Link Id="LbALQDYDZFtNStuVZtjZZj" Ids="BGdOQgGVD30NNUVRc9YbT6,D8BIJSAIkUiPV9T5F3I9Ss" />
+            <Link Id="NcJhodaXDm8QVVqEc35Mvc" Ids="D8BIJSAIkUiPV9T5F3I9Ss,SCHq8k8OuHGMxfFn21wg2k" />
+            <Link Id="JfKQAwg3eCMQBGrXPpPf9B" Ids="P6CzxIzFPytNcyX3lJyvQL,KvioOup9iqqNZkuYuXtiMV" />
           </Patch>
         </Node>
       </Canvas>
@@ -6167,7 +6106,7 @@
             <ControlPoint Id="UiDMcqi5LhJMIzJlBNPu5P" Bounds="432,533" />
             <ControlPoint Id="Itzxgq7ytA0P3qsqL9cZpM" Bounds="386,173" />
             <Node Bounds="382,197,82,26" Id="PjQ9MEcSh8HPTsT3oa1TI7">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetCalibration" />
                 <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -6177,7 +6116,7 @@
               <Pin Id="GA8PZKEEq96MNxFL09USdJ" Name="Calibration" Kind="OutputPin" />
             </Node>
             <Node Bounds="386,251,65,19" Id="HKmRdUGCW7PO9lAQcYwY81">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -6187,7 +6126,7 @@
               <Pin Id="F3KoU6xQpqhPCz58t3aA30" Name="On Data" Kind="OutputPin" />
             </Node>
             <Node Bounds="386,302,58,26" Id="DbgLlR5usw4MfFq9us4VHe">
-              <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="Nullable" />
                 <Choice Kind="OperationCallFlag" Name="HasValue" />
@@ -6197,7 +6136,7 @@
               <Pin Id="STS3g7HDqM9MNqIJQ3LbBe" Name="Has Value" Kind="OutputPin" />
             </Node>
             <Node Bounds="403,383,98,112" Id="VqCKLAsxznSMpPYJMm5zCq">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -6210,7 +6149,7 @@
                 <Patch Id="MZbqlVgrl3XNFBVvzSz9F3" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="KHSMQP9RSz5OoOeKgA6wAT" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="418,448,71,26" Id="SRLuz9olzEEMbPHzGFWF2X">
-                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                  <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Transformation" LastDependency="Microsoft.Azure.Kinect.Sensor.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Transformation" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6219,7 +6158,7 @@
                   <Pin Id="CuSXBBnQhZiQXwmcdIQnd7" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="415,406,46,26" Id="JDz7Hv4x2yAPOzLfJN3fgL">
-                  <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Nullable" />
                     <Choice Kind="OperationCallFlag" Name="Value" />
@@ -6230,8 +6169,8 @@
                 </Node>
               </Patch>
             </Node>
-            <Node Bounds="426,347" Id="NOdSUXW1vkBMOesTndLBlJ">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+            <Node Bounds="426,347,25,19" Id="NOdSUXW1vkBMOesTndLBlJ">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -6269,7 +6208,7 @@
 
 -->
       <Node Name="Timestamp" Bounds="259,417" Id="P33eGzgq04QQaqAjt4dgph">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="SZspW06ETlKQS8kRHvWADv">
@@ -6277,7 +6216,7 @@
             <ControlPoint Id="VOeBhCgoV8nPkMR6LzQqyX" Bounds="378,215" />
             <ControlPoint Id="JiVW1L6IVfrLKdjIQlUTno" Bounds="380,448" />
             <Node Bounds="370,286,124,77" Id="Hi7hzToDsFcPiS7mBFmUWf">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -6289,7 +6228,7 @@
                 <Patch Id="E4ppe19UeJKQLPpW0iPT6c" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="ONxbksr4vfdLcfqdPNZzLL" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="382,309,100,26" Id="HtTTJmGHBhbMbdy61jXw5Y">
-                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SelectTimestamp" />
                   </p:NodeReference>
@@ -6301,7 +6240,7 @@
               <ControlPoint Id="QB7sZXAoWDaMoSem7nKtxY" Bounds="383,292" Alignment="Top" />
             </Node>
             <Node Bounds="379,233,85,26" Id="Ev3gO85ztr3MyjZhHu94op">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.IDevice" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetCaptures" />
                 <CategoryReference Kind="InterfaceTypeFlag" Name="IDevice" NeedsToBeDirectParent="true" />
@@ -6311,7 +6250,7 @@
               <Pin Id="AwyrA8TmrjhLMIFtzWmEz5" Name="Captures" Kind="OutputPin" />
             </Node>
             <Node Bounds="375,402,65,19" Id="KVZp9o1mGmfLeXpzLzB7ha">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -6346,7 +6285,7 @@
 
 -->
       <Node Name="AzureKinectPlayer" Bounds="274,318" Id="Aug2wVAVucVOwnpNMqh9QI" Summary="Returns data from a recording" Tags="playback,recording">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ClassDefinition" Name="Class" />
         </p:NodeReference>
         <p:Interfaces>
@@ -6360,7 +6299,7 @@
             <ControlPoint Id="AfowIZzMqD8O4DXChtp4OD" Bounds="114,84" />
             <ControlPoint Id="VLudhzhRp0qM8bkb6wzuOd" Bounds="392,767" />
             <Node Bounds="57,124,478,570" Id="QPa019U7bDZNLWsx7RTwVp">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -6377,7 +6316,7 @@
                 <Patch Id="S5AdBETqej9ONWXcStjSDJ" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="Ltn6Aw6PCx5OJxqZ34T8id" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="57,128,660,560" Id="RZO3Nm2HbLFP3io2dpm3Ml">
-                  <p:NodeReference>
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ProcessAppFlag" Name="Try" />
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <FullNameCategoryReference ID="Control" />
@@ -6386,11 +6325,17 @@
                   <ControlPoint Id="V2GRNO5xVDzOLxInJj4YoG" Bounds="239,682" Alignment="Bottom" />
                   <ControlPoint Id="AUl1fyzosbbMY5cz62T9sh" Bounds="398,682" Alignment="Bottom" />
                   <ControlPoint Id="VXgYd9KevRbNfCR8bquecH" Bounds="585,682" Alignment="Bottom" />
+                  <Pin Id="HkyupcTH6CpNU683PhOj3v" Name="Stick To Last Valid Outputs" Kind="InputPin" />
+                  <Pin Id="BYjKnYQl4svLuMMWDvdPQm" Name="Reset Region On Failure" Kind="InputPin" />
+                  <Pin Id="ROS3ZGI2TRVLq6roLZAui9" Name="Success" Kind="OutputPin" />
+                  <Pin Id="O3zYk1A76P0LYve64OKscH" Name="Failure" Kind="OutputPin" />
+                  <Pin Id="OnpqMj5PRmQLxJa7UN6gw1" Name="Error Message" Kind="OutputPin" />
+                  <Pin Id="IdjQIK3qbQXMAMLy0wpEtC" Name="Exceptions" Kind="OutputPin" />
                   <Patch Id="JyCDa5fB7z8OI3IPWGrLbN" ManuallySortedPins="true">
                     <Patch Id="DMy2S4ofGhnMhXZMgYWppL" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="CVo1TIHFK4OOF9NIq5eTDV" Name="Update" ManuallySortedPins="true" />
                     <Node Bounds="394,563,116,26" Id="DaBZ0BYti7EQLv4QvVxmBe">
-                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="CombineLatestImages" />
                       </p:NodeReference>
@@ -6398,7 +6343,7 @@
                       <Pin Id="BeFynP0rNJkMuvPgcaW1oo" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="394,598,129,26" Id="HgAcKmcDiNwPsDf3KTKOiC">
-                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.KinectImageExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="DecompressColorImages" />
                       </p:NodeReference>
@@ -6406,7 +6351,7 @@
                       <Pin Id="GX1VebDFVukPN8uJJqyUMj" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="394,634,75,26" Id="SlghcixGkvvNGMkp5S3ztN">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="PubRefCount" />
                       </p:NodeReference>
@@ -6414,7 +6359,7 @@
                       <Pin Id="HPcpw8zoiPsK9t9eVsHiuD" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="394,393,77,137" Id="PTB9O8xRsfUMmDlN9Wm9tY">
-                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.ResourceExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                      <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.ResourceExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                         <Choice Kind="OperationCallFlag" Name="PollResourceAndYield" />
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       </p:NodeReference>
@@ -6429,7 +6374,7 @@
                         <ControlPoint Id="OrkUCJJ6mzyMpHMAGHcvHJ" Bounds="408,401" />
                         <ControlPoint Id="FEJpcWeI9IIPucaqvRL70B" Bounds="408,523" />
                         <Node Bounds="406,473,-24,19" Id="SBpHBuMvpR7N9mi5Q9fBWQ">
-                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="Player" />
                           </p:NodeReference>
@@ -6438,7 +6383,7 @@
                           <Pin Id="MxnNftyb2zvNqvdThcIR9J" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="408,432,51,26" Id="KleYd0aT1sJMr9Oa2EXEbd">
-                          <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Data" />
                             <CategoryReference Kind="ClassType" Name="Reference" NeedsToBeDirectParent="true" />
@@ -6450,7 +6395,7 @@
                       </Patch>
                     </Node>
                     <Node Bounds="228,412,123,225" Id="Qh6AIrqYRvcNTlaqnL73sp">
-                      <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                         <CategoryReference Kind="Category" Name="Resources" />
                         <Choice Kind="OperationCallFlag" Name="Using (Select)" />
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -6463,7 +6408,7 @@
                         <ControlPoint Id="VmoB3foAjoyNbPw0pSy8rj" Bounds="242,420" />
                         <ControlPoint Id="E5gZL1bKr4IQLzSQTDtXHp" Bounds="247,630" />
                         <Node Bounds="240,449,93,26" Id="ECL4az9HpksLpqtyLYcBpj">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                             <Choice Kind="OperationCallFlag" Name="RecordingLength" />
@@ -6473,7 +6418,7 @@
                           <Pin Id="DX1ixHMt4blPBFpixwno9H" Name="Recording Length" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="244,511,95,26" Id="HMKgq209MhIM6KflY3YlCQ">
-                          <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                           </p:NodeReference>
@@ -6481,7 +6426,7 @@
                           <Pin Id="QF0Z9xhRonIPRwrvFE0xuz" Name="Total Seconds" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="244,551,62,19" Id="D3qrHFJcQwQNYfR0de2vgj">
-                          <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                           </p:NodeReference>
@@ -6491,17 +6436,19 @@
                       </Patch>
                     </Node>
                     <Node Bounds="99,484,90,124" Id="MA65dcyMOZILH4UECCdlK3">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Using (Provider)" />
                       </p:NodeReference>
+                      <Pin Id="F3xd7fIyhSRM1L25DQ3qW6" Name="Provider" Kind="InputPin" />
+                      <Pin Id="V2GinOpuPgvPpOdbpdouGh" Name="Result" Kind="OutputPin" />
                       <Patch Id="PiME9fwQVZFMpk6fTnmkrV" Name="Observable Factory" ManuallySortedPins="true">
                         <Pin Id="ESHZ8vi3d9EQEEhT1vOFZF" Name="Input" Kind="InputPin" />
                         <Pin Id="OBDF506tC0vPBGDAoxku9W" Name="Result" Kind="OutputPin" />
                         <ControlPoint Id="Ei7V284kPdrMcLAu66vo7E" Bounds="113,492" />
                         <ControlPoint Id="EwA4KE5dSBgLFatv61t9YY" Bounds="114,601" />
                         <Node Bounds="111,508,66,26" Id="Vho6zIlNjZGPbfwefmyt7R">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                             <Choice Kind="OperationCallFlag" Name="Calibration" />
@@ -6511,7 +6458,7 @@
                           <Pin Id="P3VHyQiTr6CP0EpjDgysE7" Name="Calibration" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="112,554,46,19" Id="TrEg5qWUqQCP1JobCviElb">
-                          <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                          <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Return" />
                             <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -6520,11 +6467,9 @@
                           <Pin Id="TG2xWLiRN1MPHA5m8oQ4Ae" Name="Result" Kind="OutputPin" />
                         </Node>
                       </Patch>
-                      <Pin Id="F3xd7fIyhSRM1L25DQ3qW6" Name="Provider" Kind="InputPin" />
-                      <Pin Id="V2GinOpuPgvPpOdbpdouGh" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="100,148,79,97" Id="Bj0WfEUDBcRPekigt6jTL5">
-                      <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                         <CategoryReference Kind="Category" Name="Resources" />
                         <Choice Kind="OperationCallFlag" Name="New" />
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -6534,7 +6479,7 @@
                         <Pin Id="ExSWESk4knHO1EHGQOtlHK" Name="Result" Kind="OutputPin" />
                         <ControlPoint Id="TY4elYMEGFYPw5NvxcdpyN" Bounds="114,238" />
                         <Node Bounds="112,200,41,19" Id="U4hoCaO8BEQP017XPKhA69">
-                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                          <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                             <Choice Kind="OperationCallFlag" Name="Open" />
@@ -6543,7 +6488,7 @@
                           <Pin Id="IzgPu4k88EBLI0ArJ4FgeN" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="112,171,55,19" Id="S4F0fWKnMTYOc53PmzpXvq">
-                          <p:NodeReference LastCategoryFullName="IO.Path" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="Category" Name="Path" />
                             <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -6554,7 +6499,7 @@
                       </Patch>
                     </Node>
                     <Node Bounds="100,261,83,26" Id="SYRtpFJhcZkNw1XQYO1mrq">
-                      <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ShareInParallel" />
                         <PinReference Kind="InputPin" Name="Delay Disposal In Milliseconds" />
@@ -6564,15 +6509,18 @@
                       <Pin Id="G6h58LhREroLRXXATcGoSv" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="580,397,125,136" Id="MoyuTgKfeFwLSXtO3FrUOv">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="PollData" />
                       </p:NodeReference>
+                      <Pin Id="FrUVGO7wFsWLNfbP11E0Po" Name="Device Provider" Kind="InputPin" />
+                      <Pin Id="LcPXTFqToINMRVysQhjll5" Name="Milliseconds Delay" Kind="InputPin" />
+                      <Pin Id="EceiXQLw8eiMhkkzfSdayW" Name="Result" Kind="OutputPin" />
                       <Patch Id="CsN9D0ApObSPiIHpM1ha8n" ManuallySortedPins="true">
                         <ControlPoint Id="Il4LITDv3fWOgg0Nla4tvi" Bounds="649,405" />
                         <ControlPoint Id="AO9TAPdYLOBOB9VSauzaTY" Bounds="594,526" />
                         <Node Bounds="592,476,61,19" Id="MUPtIFvAgk4PR8BGk6fd8S">
-                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                          <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="ImuPlayer" />
                           </p:NodeReference>
@@ -6581,7 +6529,7 @@
                           <Pin Id="U38Jbr0HjLwLpar7y1NWIa" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="593,421,51,26" Id="KlRzfUlCgcEOwwSRyvUFBU">
-                          <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Data" />
                             <CategoryReference Kind="ClassType" Name="Reference" NeedsToBeDirectParent="true" />
@@ -6599,12 +6547,9 @@
                           <Pin Id="Lb6eZ2EPh7zLFmT5Pt0gio" Name="Output" Kind="OutputPin" />
                         </Patch>
                       </Patch>
-                      <Pin Id="FrUVGO7wFsWLNfbP11E0Po" Name="Device Provider" Kind="InputPin" />
-                      <Pin Id="LcPXTFqToINMRVysQhjll5" Name="Milliseconds Delay" Kind="InputPin" />
-                      <Pin Id="EceiXQLw8eiMhkkzfSdayW" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="581,632,75,26" Id="StT7VkhZtU1Ndj7EdQthQM">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="PubRefCount" />
                       </p:NodeReference>
@@ -6612,7 +6557,7 @@
                       <Pin Id="PSZA3cDh6YlN9XP8Iz3BEB" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="581,571,91,26" Id="K0kcziBWLqMN3cUmd8PjcJ">
-                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                      <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="BackoffAndRetry" />
                         <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
@@ -6622,12 +6567,6 @@
                       <Pin Id="ODVpWt39gcQO0Cz2mR1303" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="HkyupcTH6CpNU683PhOj3v" Name="Stick To Last Valid Outputs" Kind="InputPin" />
-                  <Pin Id="BYjKnYQl4svLuMMWDvdPQm" Name="Reset Region On Failure" Kind="InputPin" />
-                  <Pin Id="ROS3ZGI2TRVLq6roLZAui9" Name="Success" Kind="OutputPin" />
-                  <Pin Id="O3zYk1A76P0LYve64OKscH" Name="Failure" Kind="OutputPin" />
-                  <Pin Id="OnpqMj5PRmQLxJa7UN6gw1" Name="Error Message" Kind="OutputPin" />
-                  <Pin Id="IdjQIK3qbQXMAMLy0wpEtC" Name="Exceptions" Kind="OutputPin" />
                 </Node>
               </Patch>
             </Node>
@@ -6637,20 +6576,20 @@
 
 -->
             <Node Name="Player (Internal)" Bounds="766,619" Id="HUcZfraYwX1MtIi63r0BeU">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ClassDefinition" Name="Class" />
               </p:NodeReference>
               <Patch Id="B4OyLG4uua1LldULanlRpL">
                 <Canvas Id="NnaPeCGMErULVf2hKG5Row" CanvasType="Group">
                   <Node Bounds="564,-41,73,19" Id="BaPXojhN4K5PioRo9UkEOj">
-                    <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="CurrentTime" />
                     </p:NodeReference>
                     <Pin Id="M5Dcnq72YipM86w7tbOxtO" Name="Current Time" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,-4,54,26" Id="OldrwnncyBKOyHr1RwvgcR">
-                    <p:NodeReference LastCategoryFullName="Animation.Time" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation.Time" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Time" />
                       <Choice Kind="OperationCallFlag" Name="Seconds" />
@@ -6659,7 +6598,7 @@
                     <Pin Id="PLyUZugSNNFLqrrG9kJu8i" Name="Seconds" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,40,91,19" Id="SbJ9UCiJ9mJPjVjdhZBujH">
-                    <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="FrameDifference" />
                     </p:NodeReference>
@@ -6667,7 +6606,7 @@
                     <Pin Id="P3gnqYjsftcNS1a0iqexSS" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,138,25,19" Id="Gyil49TrsP5PlxL4CaLKxE">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
@@ -6678,7 +6617,7 @@
                   </Node>
                   <Pad Id="IwCy1qjtbtvNaMYLckAErK" SlotId="PbuY8nTtSIiNCI4pu1rKEp" Bounds="808,116" />
                   <Node Bounds="806,141,25,19" Id="M1xhNmn6MzXLuG3rseGJFi">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6696,12 +6635,12 @@
 
 -->
                   <Node Name="FetchNextAndLoop (Internal)" Bounds="779,696,346,680" Id="N3KXAutXbQeOP3F7a1TOHg">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="LXJ2it4yp5IMNe98yoA7Lt">
                       <Node Bounds="796,742,89,26" Id="UgcnvCRSXF7OicSyxKJFZl">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetNextCapture" />
                         </p:NodeReference>
@@ -6713,7 +6652,7 @@
                       <Link Id="Goy9PRWg8svMHpzCk7Q6Ob" Ids="IfHUC3ViO6mNIXMPT9ueHT,LwRWlSFuFmbMTpQKGokrx0" />
                       <Link Id="QNPL8fedjZTNGlRbvx7Ocp" Ids="CLk0iKxlaC1Mq3kGlLHUNn,IfHUC3ViO6mNIXMPT9ueHT" IsHidden="true" />
                       <Node Bounds="852,852,65,19" Id="TUm1QNs3g1JLO8wb88dWNL">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -6722,7 +6661,7 @@
                         <Pin Id="Fll0a0zPL7VMWy2ceVXqdZ" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="802,1208,117,122" Id="ICPzVIUbjncL9D28FzsgU0">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -6732,7 +6671,7 @@
                           <Patch Id="May0bAbruCBLuV7rL4bs7p" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="NmTgyGvLAYlNnMLUw2t1P7" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="814,1235,47,26" Id="Gm0lrZSxcRFOeegBsZCg6P">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                               <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -6743,7 +6682,7 @@
                             <Pin Id="PUucn1IxW5FL99b2YIrcG0" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="814,1275,89,26" Id="MWoNRKla9aLLNtGkX5InPb">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetNextCapture" />
                             </p:NodeReference>
@@ -6758,7 +6697,7 @@
                       <Link Id="ODAq5RFNbT8LMnWXGbZUsE" Ids="OtGA2q7ISJlNMW8AFePsmA,I2NWxciC0sALn3Km2MC1jf" />
                       <Link Id="IUtimoQ05KULs3ydd5YHbU" Ids="UuJSsMKamilPEmoa6DvUVg,MtqQkt1ObXDO8zGxfg9QUL" />
                       <Node Bounds="798,1145,37,19" Id="ANF3h12xRQoO8jeqclB5pZ">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -6777,7 +6716,7 @@
                       <ControlPoint Id="UiAqZLCjf9hLPk0jJXcOE4" Bounds="903,1359" />
                       <Link Id="CAfGDBYfNYbOFYke43Vkzo" Ids="UiAqZLCjf9hLPk0jJXcOE4,OWqJh0zpxeZMaqsScCL5VL" IsHidden="true" />
                       <Node Bounds="1019,948,38,26" Id="U4Im28oIie5NI1xXsmuLQH">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -6792,7 +6731,7 @@
                       <Link Id="AVDUBUey3zGPEvBZ4eBTt7" Ids="L0m6yUfsE0TQR8g1pZB8T4,GURsp28xJF9OC1zlN4QDnO" />
                       <Link Id="Kidm8VCndGQPDElWR1wK1O" Ids="RM4EHEV5hQXLS5XeFgEIqn,RXhlwVF952GN8y0eMMYCMq" />
                       <Node Bounds="1022,1170,25,19" Id="KvfQelgoqYsOHN84s2j0up">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -6804,17 +6743,19 @@
                       <Link Id="MEYoUkfFXCoMcFd9GqRDmB" Ids="VRo0SZm7u0INxZsiZgqVPT,RN8JjHxPgkZPj4zQddW0YW" />
                       <Link Id="C6Hp7IGIIPoOt3y2IclDuo" Ids="TWwi2Hk25ZeNujIcayhsgV,VRo0SZm7u0INxZsiZgqVPT" IsHidden="true" />
                       <Node Bounds="852,927,111,114" Id="UWNX3ZpVsOxMpJGl3ZOSDT">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="TCxnmLpkScpN8Op9tD6cAj" Name="Condition" Kind="InputPin" />
+                        <ControlPoint Id="MeWPXx9YL1XPIrymvSvWCj" Bounds="867,1035" Alignment="Bottom" />
+                        <ControlPoint Id="UteHwRGB9bTMg9UJP7CHcZ" Bounds="866,933" Alignment="Top" />
                         <Patch Id="Taw5R2RL6foMRx3ZMMdXrl" ManuallySortedPins="true">
                           <Patch Id="DFzC6a1oPTlQbqRNfgvDzu" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="TYp9zdgHmFTLH7TQoeu1gW" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="865,956,86,26" Id="Q136x321V5INxdnjKnYDC1">
-                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                               <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -6823,7 +6764,7 @@
                             <Pin Id="RGalsHFEmQDODOJ8s5Kuo6" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="865,996,25,19" Id="EIb70jgtUZtPdbQvbWOoiu">
-                            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="&gt;" />
                             </p:NodeReference>
@@ -6832,8 +6773,6 @@
                             <Pin Id="Ix9AROqkgwnNThGOEf6CuW" Name="Result" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="MeWPXx9YL1XPIrymvSvWCj" Bounds="867,1035" Alignment="Bottom" />
-                        <ControlPoint Id="UteHwRGB9bTMg9UJP7CHcZ" Bounds="866,933" Alignment="Top" />
                       </Node>
                       <Link Id="F0H3gWAJ0lGOc5Se2jUzjH" Ids="OGG2iFgfDJnMO6VV5arcej,TCxnmLpkScpN8Op9tD6cAj" />
                       <Link Id="MSfRS5slHwMP2lRiA1jiQI" Ids="UteHwRGB9bTMg9UJP7CHcZ,MeWPXx9YL1XPIrymvSvWCj" IsFeedback="true" />
@@ -6842,7 +6781,7 @@
                       <Link Id="IgvDxizyUDaLMMP1L6Q7iX" Ids="CRWFW24kW3FQEahYIvCSUa,IrplUIEbTMzMKNlpJoHayb" />
                       <Link Id="RzdcQSdKXLHMJpfZ3Hyg2e" Ids="Ix9AROqkgwnNThGOEf6CuW,MeWPXx9YL1XPIrymvSvWCj" />
                       <Pad Id="LuRKLq1b17sNjbbwgE8jQ0" Comment="" Bounds="866,889,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -6851,9 +6790,8 @@
                       <Link Id="QvdqziKgE2IPnfZYHLt7mA" Ids="L0m6yUfsE0TQR8g1pZB8T4,ETKMuvbIdXtNNhlr7oie7s" />
                       <Pin Id="CLk0iKxlaC1Mq3kGlLHUNn" Name="Input" Kind="InputPin" Bounds="1442,875" />
                       <Pin Id="NueVlrtONeUL99dXDS0gdx" Name="Loop" Kind="InputPin" Bounds="1616,904" />
-                      <Pin Id="OWqJh0zpxeZMaqsScCL5VL" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="HgwuWKAf4VHPkvC6l1fgji" Name="Time Range" Kind="InputPin" Bounds="1598,1017">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Range" />
                           <p:TypeArguments>
                             <TypeReference>
@@ -6863,6 +6801,7 @@
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="TWwi2Hk25ZeNujIcayhsgV" Name="Initial Offset" Kind="InputPin" Bounds="1668,700" />
+                      <Pin Id="OWqJh0zpxeZMaqsScCL5VL" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                     </Patch>
                   </Node>
                   <!--
@@ -6871,12 +6810,12 @@
 
 -->
                   <Node Name="FetchPreviousAndLoop (Internal)" Bounds="1266,701,299,669" Id="H3rQX4b92gmMOSYQqfU6HK">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="D9vSuw8MQZfNZacyzFZTAe">
                       <Node Bounds="1293,746,106,26" Id="Gso6OYJUt2UPLklHo9yrTa">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPreviousCapture" />
                         </p:NodeReference>
@@ -6888,7 +6827,7 @@
                       <Link Id="DMNYmQipbWrPwMLUA2G7HK" Ids="F7fPVHB6tzaMTflf61hD8E,PDaC85wmIWhOi41f6Sp7at" />
                       <Link Id="BVVzS7ssH6hL9YdCmKM3Pm" Ids="FcnYcIwXyyfOstuAA6oeB1,F7fPVHB6tzaMTflf61hD8E" IsHidden="true" />
                       <Node Bounds="1289,1208,132,119" Id="JINutw8YAxmNh73JsWg8Cz">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -6900,7 +6839,7 @@
                           <Patch Id="HdyjpV6hxYCQBLIdvsI5P4" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="P4UZd1YJIkYMfFcxacOkqP" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="1301,1234,47,26" Id="CWrnheV7aOIPp2dymiI43O">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                               <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -6911,7 +6850,7 @@
                             <Pin Id="V8LijF15nMZQFGhukKEMnv" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="1301,1276,106,26" Id="QuwIsZHcYrVLkNWVvHIRb9">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetPreviousCapture" />
                             </p:NodeReference>
@@ -6923,7 +6862,7 @@
                       </Node>
                       <Link Id="Mkxmu0PNZeTQXW1r4DxMX2" Ids="PQtLXLrrVLNPxB0upAAkHJ,BWVcZCUF7JVOrEOZDVU3rp" />
                       <Node Bounds="1291,1157,37,19" Id="V8HPUb2i5UaMmZme5nv9al">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -6942,7 +6881,7 @@
                       <ControlPoint Id="CXwYu2WGxGaMHmsKS9MI3E" Bounds="1408,1353" />
                       <Link Id="Vs5n4v95GGYL8o7pWt5YE1" Ids="CXwYu2WGxGaMHmsKS9MI3E,Cygr1r7LJBtP9XiGP6JHgj" IsHidden="true" />
                       <Node Bounds="1459,929,38,26" Id="IKxieOQHE0aPi1mobRn7VA">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -6956,7 +6895,7 @@
                       <Link Id="NALybMrrj2TQV4FexIkF3P" Ids="E9iVVuXQnPgQJ79UsgyMbv,MvDP7AAwjk8NpftYXt2L0S" IsHidden="true" />
                       <Link Id="QZBSXLjnb75MWkgRfCAavx" Ids="Kb1UkEmURkFP8ogEu6WqDH,GSWsIbLZhE9OLKCjn6HpIu" />
                       <Node Bounds="1464,1142,25,19" Id="VTcbIJS7bI9OuFBAjqG3VV">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -6969,7 +6908,7 @@
                       <Link Id="BWHoKrI4qb8PAPsk3MnkW3" Ids="CA7xJ0aC1TFL4RO9avmvze,JHgOQ6OPdfkNOUEOoA4WS9" IsHidden="true" />
                       <Link Id="RrCdZShl3IaMHhH261y96R" Ids="Bo7QF7Q92B3OxAppZrL4sD,AF7kL8bOk2kMFJGmFWjqzZ" />
                       <Node Bounds="1327,843,65,19" Id="ArkuT0tI0PEMzQOtcyia5x">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -6978,17 +6917,19 @@
                         <Pin Id="MXW2dr4UjQiLvHUEJH2wmQ" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1327,918,111,114" Id="UShyktRztkBNAVkPBr98rj">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="B99ISllozjPNd5uQr6Pv1w" Name="Condition" Kind="InputPin" />
+                        <ControlPoint Id="VC0LIWFuycVLN1mBe7gZ0I" Bounds="1342,1026" Alignment="Bottom" />
+                        <ControlPoint Id="ICwrk63pKoHL8oENQ6bq1V" Bounds="1341,924" Alignment="Top" />
                         <Patch Id="Shjpyk9oxvUL0E6Q8vo2gs" ManuallySortedPins="true">
                           <Patch Id="IqemLw5s2e7Lb9ZVmqF3za" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="HjHaSn6E4eDNNeCTlG3wQi" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="1340,947,86,26" Id="HiCPFCL7yIzQG0i83hIrGl">
-                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                               <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -6997,7 +6938,7 @@
                             <Pin Id="PKi3xCtoqKdO1cRu14NJ1E" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1340,987,25,19" Id="TI5jeGfsYx9L2qlGxMhGC1">
-                            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="&lt;" />
                               <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -7007,11 +6948,9 @@
                             <Pin Id="DknC7H2HisJLqAK0tkEPFG" Name="Result" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="VC0LIWFuycVLN1mBe7gZ0I" Bounds="1342,1026" Alignment="Bottom" />
-                        <ControlPoint Id="ICwrk63pKoHL8oENQ6bq1V" Bounds="1341,924" Alignment="Top" />
                       </Node>
                       <Pad Id="PrJL5d1AHkDL6CYwNrQuwh" Comment="" Bounds="1341,880,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -7027,9 +6966,8 @@
                       <Link Id="LPQoAzioMXGOHpgxTCE8Ds" Ids="CHvZGZv7aguOIvKNRzRiyF,T92k6KClODhNA35RvPeCAe" />
                       <Pin Id="FcnYcIwXyyfOstuAA6oeB1" Name="Input" Kind="InputPin" Bounds="1442,875" />
                       <Pin Id="SxsF235S8l8QLT2C4fqnWq" Name="Loop" Kind="InputPin" Bounds="1616,904" />
-                      <Pin Id="Cygr1r7LJBtP9XiGP6JHgj" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="E9iVVuXQnPgQJ79UsgyMbv" Name="Time Range" Kind="InputPin" Bounds="1598,1017">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Range" />
                           <p:TypeArguments>
                             <TypeReference>
@@ -7039,11 +6977,12 @@
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="CA7xJ0aC1TFL4RO9avmvze" Name="Initial Offset" Kind="InputPin" Bounds="1668,700" />
+                      <Pin Id="Cygr1r7LJBtP9XiGP6JHgj" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                     </Patch>
                   </Node>
                   <Pad Id="RQvpPg39UA3MrspFgbBOUp" SlotId="RVNdUq1yU5vOFgWXY6ff1K" Bounds="896,416" />
                   <Node Bounds="874,435,25,19" Id="KMIJCD8Ki4YNuGyD4pogzv">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="-" />
                     </p:NodeReference>
@@ -7052,7 +6991,7 @@
                     <Pin Id="Cds2x89NUDXOU9juY9LIfo" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="874,467,34,19" Id="UqIQyjht1LDL9oHfVS3hha">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Abs" />
                     </p:NodeReference>
@@ -7060,14 +6999,14 @@
                     <Pin Id="H7TAfrPybVKNXLjpoBvQzM" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="326,705,40,19" Id="IXXJypx2HtCOtf3UsVEZPE">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NULL" />
                     </p:NodeReference>
                     <Pin Id="LNgraPcOMPNLCr8SqMS8uR" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="359,166,131,26" Id="RHSUSwUBmcpM0yXgdROd9U">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                       <Choice Kind="OperationCallFlag" Name="GetStartTimestampOffset" />
@@ -7076,7 +7015,7 @@
                     <Pin Id="P6nYyr4uE14MdVEHLun4xN" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="238,207,86,26" Id="Q25JNwGYk7HPAlDWbVN0WT">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                       <Choice Kind="OperationCallFlag" Name="GetFrameRate" />
@@ -7085,12 +7024,12 @@
                     <Pin Id="FgzlE0k9XvtLwg5Jb0Whpx" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="218,277,25,19" Id="EcLUsHSUc6mMBNeNt4wr6t">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="/" />
                     </p:NodeReference>
                     <Pin Id="NCQx11UPZEBLVlxmQrgSOK" Name="Input" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -7098,7 +7037,7 @@
                     <Pin Id="RoTimJzuoKULkBqYwSxCQz" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="238,246,62,19" Id="FxZLTU2jxGAOt3BKNFbFuV">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                     </p:NodeReference>
@@ -7106,7 +7045,7 @@
                     <Pin Id="UWhwllZw7TLMPrg65bAZHj" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="289,742,309,251" Id="HnrVt1AjBmBLzNkbyJPIdF">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -7120,7 +7059,7 @@
                       <Patch Id="Eog5xOwSjiNNlsBDMhDRB4" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="Hw8ddtnvPUgMJNoO1beFEc" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="313,774,127,90" Id="NOxms1NWih6QCNXq7k3epa">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
@@ -7132,7 +7071,7 @@
                           <Patch Id="CdmVh9jwltDQG10wNKleJt" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="JUwqQzs1ZuIMj1aEYqfW14" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="325,810,103,19" Id="UYEoCnbjPw0OOv1Q5CAKWR">
-                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice2.Player" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.Player" LastDependency="VL.Devices.AzureKinect.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FetchNextAndLoop" />
                               <CategoryReference Kind="ClassType" Name="Player" NeedsToBeDirectParent="true" />
@@ -7146,7 +7085,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="312,880,143,88" Id="FNUPyKnbuuQMF7evZlPjRp">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
@@ -7158,7 +7097,7 @@
                           <Patch Id="QYWzrXaWp3EOdCHwlyAwAx" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="L9OumF6tJZBNnjyfCJM00t" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="324,913,119,19" Id="P1W8QEGgj1IL7h5cuolcVt">
-                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice2.Player" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.Player" LastDependency="VL.Devices.AzureKinect.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FetchPreviousAndLoop" />
                               <CategoryReference Kind="ClassType" Name="Player" NeedsToBeDirectParent="true" />
@@ -7174,7 +7113,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="874,533,25,19" Id="HBqs7cjEWfgMahNnYjPct1">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -7184,20 +7123,20 @@
                     <Pin Id="HGtPGnRSM7nQbiCJj9BlRH" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="894,502,25,19" Id="R5XWjszfhFSP3pWFXsTT8a">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
                     <Pin Id="CSFQARlSl16OvjVwAfJb32" Name="Input" Kind="InputPin" />
                     <Pin Id="Euu6ghaAxpVQZRruUdswTb" Name="Scalar" Kind="InputPin" DefaultValue="0.5">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="D1rkYDhpc7lLgfsZA4OSuN" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="249,656,65,26" Id="CNnBLtYdWoCQXU5huV9r0N">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                       <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -7209,7 +7148,7 @@
                     <Pin Id="NpTxjEAGfqQMd1YYNqdHSP" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="316,593,77,19" Id="C4rkkutYB5gMMcH9l6AGJU">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromSeconds" />
                       <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -7218,7 +7157,7 @@
                     <Pin Id="RXsFLyNOtNSMEr5Xp6lIiu" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="382,1091,65,19" Id="UvcOa0WG8uDL22WWTf4tys">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -7227,17 +7166,19 @@
                     <Pin Id="Ts6QW8gW56CPowFI2j6aQo" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="387,1172,110,166" Id="SFRdRQC9aHzNqpPzXP6Ni6">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
                     <Pin Id="BH47bt163yuQCCXrEO6ze6" Name="Condition" Kind="InputPin" />
+                    <ControlPoint Id="AIHH6BLQmXSO8zcpsGcHCc" Bounds="408,1332" Alignment="Bottom" />
+                    <ControlPoint Id="FgPtuhd57aqPy3uhDH7UG6" Bounds="408,1178" Alignment="Top" />
                     <Patch Id="GXAGkAnfADXNgbzgOrD5hH" ManuallySortedPins="true">
                       <Patch Id="DN4oxrksxwpL3o3EIBOW4b" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="OY0o7A60rgaPcuMqnIZrEX" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="399,1211,86,26" Id="AxN8KmAzA2JM55cEw2HOjQ">
-                        <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                        <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                           <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -7246,7 +7187,7 @@
                         <Pin Id="SfgWBYofEWUNV0IqMFgrlO" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="399,1254,77,26" Id="AidvM5Vd7CaLbZFUYLkhQC">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -7254,13 +7195,11 @@
                         <Pin Id="IsO8vZ7AL0yMpzsJRq19dw" Name="Total Seconds" Kind="OutputPin" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="AIHH6BLQmXSO8zcpsGcHCc" Bounds="408,1332" Alignment="Bottom" />
-                    <ControlPoint Id="FgPtuhd57aqPy3uhDH7UG6" Bounds="408,1178" Alignment="Top" />
                   </Node>
                   <Pad Id="IJJRteIoha3NgIlOvIzAbM" SlotId="RVNdUq1yU5vOFgWXY6ff1K" Bounds="413,1141" />
                   <Pad Id="IUItm5YijvGPx5lSDGMY86" SlotId="OZCkp2fnvyzMrxWDqlvEg5" Bounds="546,231" />
                   <Node Bounds="544,258,25,19" Id="QHTWPpNiGogM8EPqxkJlF3">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -7270,7 +7209,7 @@
                   </Node>
                   <Pad Id="PYn1MBF69i8P2mG18ODHJc" SlotId="OZCkp2fnvyzMrxWDqlvEg5" Bounds="582,1034" />
                   <Node Bounds="192,339,31,19" Id="JA9HnnABUv2LIpS6FEsaeM">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;=" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -7280,7 +7219,7 @@
                     <Pin Id="EicmZ9jJWaVME6YzfnEzDt" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="148,741,31,19" Id="MpcWjxUcOlUMGs4IC5ROhx">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;=" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -7290,7 +7229,7 @@
                     <Pin Id="K39cx05WfAoMYKjJO5yzNF" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="146,850,25,19" Id="LHVvMA9M4nBMibmX3tYxGZ">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&lt;" />
                     </p:NodeReference>
@@ -7299,7 +7238,7 @@
                     <Pin Id="SarhhQQGgJDQFK2lEPg29r" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="584,105,34,19" Id="Vt7jGrnKkQTMZBQmVfCKw2">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Abs" />
                     </p:NodeReference>
@@ -7307,7 +7246,7 @@
                     <Pin Id="OtCsj7lbroUOeyi1972Znw" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="826,102,25,19" Id="TSFcSiKU8txMIRbHskqDNZ">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
@@ -7317,7 +7256,7 @@
                     <Pin Id="OpJ5jRCq3SgQS04WTVK7Fp" Name="Scalar 2" Kind="InputPin" />
                   </Node>
                   <Node Bounds="270,628,25,19" Id="FmE7GXRy1svPYcOpe06xgz">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -7331,12 +7270,12 @@
 
 -->
                   <Node Name="TimeLoop" Bounds="1285,295,263,189" Id="GzR7YMeVkSnPF2cpNPe7c3">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="NykyBd4INJLQbyoWX60Arv">
                       <Node Bounds="1298,423,105,19" Id="KtT41TMKU4YPWMsinOombn">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="MapWrap" />
                           <CategoryReference Kind="Category" Name="Ranges" NeedsToBeDirectParent="true" />
@@ -7350,7 +7289,7 @@
                       </Node>
                       <ControlPoint Id="QvpHBkWxdHLQUcxOLzJR6M" Bounds="1359,313" />
                       <Node Bounds="1357,330,38,26" Id="Vkm9Gr0yruvNcaEk6vMxus">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -7360,7 +7299,7 @@
                         <Pin Id="H1xTKldvoIEOsA4602HHFM" Name="To" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1357,369,77,26" Id="VBi7fAtNsguLcq1YdmF7Uw">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -7368,7 +7307,7 @@
                         <Pin Id="DUIyQooAIK4M6TyBHVEG85" Name="Total Seconds" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1459,369,77,26" Id="PxXgFh7MXWqLbx0ES3S1vY">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -7395,7 +7334,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="806,181,126,19" Id="FQCohaXV3fnQMTsPQJJ4r4">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.Player" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.Player" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="TimeLoop" />
                       <CategoryReference Kind="ClassType" Name="Player" NeedsToBeDirectParent="true" />
@@ -7406,7 +7345,7 @@
                     <Pin Id="PL83LBen6KuP6yoQ3kuhQ2" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="794,302,31,41" Id="LTnRNWIIItIOhyoSz54V0A">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -7420,7 +7359,7 @@
                     <ControlPoint Id="BDohtktfM5zMyFa2jHCXDH" Bounds="808,309" Alignment="Top" />
                   </Node>
                   <Node Bounds="166,554,65,26" Id="SjDUv5jbYD2OUhRoWBwnJO">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                       <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -7432,7 +7371,7 @@
                     <Pin Id="Jn9MRn5lMFUOjLdS4y94wU" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="842,565,37,19" Id="CliYrGCEOVBO48a8jijDxh">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                     </p:NodeReference>
@@ -7442,7 +7381,7 @@
                   </Node>
                   <ControlPoint Id="Uu1F6nJiyUIMF3K5zNHrs2" Bounds="918,47" />
                   <Node Bounds="916,70,82,26" Id="HfVIRuMFzzIMj9ueJSKuzz">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetTimeRange" />
                     </p:NodeReference>
@@ -7451,7 +7390,7 @@
                   </Node>
                   <ControlPoint Id="BJyS30z2Zp6LFsp8GX7r23" Bounds="593,736" />
                   <Node Bounds="591,759,82,26" Id="LgHw1WKHj9NPcHd8k3hVSd">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetTimeRange" />
                     </p:NodeReference>
@@ -7459,7 +7398,7 @@
                     <Pin Id="IfZ7LlpxQeiLjjpLsyhmOU" Name="Time Range" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="794,262,123,26" Id="Ut4j78KdcWIPxPh2AxoHyA">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSyncToExternalTime" />
                     </p:NodeReference>
@@ -7471,7 +7410,7 @@
                   <ControlPoint Id="Q7XlsrsaVotPFS7GElGlF6" Bounds="796,241" />
                   <ControlPoint Id="NrgfLg6UkWcNaGIaLUTsjU" Bounds="749,-36" />
                   <Node Bounds="747,-9,64,26" Id="LsGKETa21kzQHmbMjPAYv3">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSpeed" />
                     </p:NodeReference>
@@ -7480,7 +7419,7 @@
                   </Node>
                   <ControlPoint Id="Vbqup0KGn72LJJtkxnHeqt" Bounds="1021,107" />
                   <Node Bounds="1019,122,64,26" Id="TKkbmWGpoaGLzkT2ypJSjq">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetLoop" />
                     </p:NodeReference>
@@ -7489,7 +7428,7 @@
                   </Node>
                   <ControlPoint Id="RPrWooahrpVLofNmBAExCB" Bounds="592,663" />
                   <Node Bounds="590,678,64,26" Id="CxOlwPx8XQ6LoSDiYzPxir">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetLoop" />
                     </p:NodeReference>
@@ -7497,12 +7436,12 @@
                     <Pin Id="PYrslDomSkbPtzRw2PXfIA" Name="Loop" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="226,514,57,19" Id="ONWw6ZLVxhbPE0dy7dPjn8">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Changed" />
                     </p:NodeReference>
                     <Pin Id="D2yGiSO2SW3NESpfH94yAd" Name="Changed On Create" Kind="InputPin" DefaultValue="False">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -7511,7 +7450,7 @@
                     <Pin Id="Iv97ULjaAoaOtzZts8aoPd" Name="Unchanged" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="186,458,64,26" Id="KiIsys3KB2UP9xgcTtlEmi">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSeek" />
                     </p:NodeReference>
@@ -7522,7 +7461,7 @@
                   <ControlPoint Id="HhRlTZ7DtoqN1yOOoUyU4s" Bounds="188,442" />
                   <ControlPoint Id="UZHwkTW9dTpPB3Pp4TmVf4" Bounds="110,665" />
                   <Node Bounds="108,692,64,26" Id="EbYFBQ6NZUTPfNEGp9bIzp">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSpeed" />
                     </p:NodeReference>
@@ -7531,7 +7470,7 @@
                   </Node>
                   <ControlPoint Id="GztfyHX22CWNpM3XviwOds" Bounds="870,-34" />
                   <Node Bounds="868,-7,64,26" Id="NWdicrzzAtwPjDT8qoHYNF">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetPlay" />
                     </p:NodeReference>
@@ -7656,7 +7595,7 @@
                 <Patch Id="MxDscEPWixkQMFypclfoYq" Name="Create" />
                 <Patch Id="OKa6B8ElssbPGFXh4Olehh" Name="Update" ParticipatingElements="PEGUp0kKIOVMSuzbBtdWoB">
                   <Pin Id="C9DsTWpaclhO50iMxe7UW5" Name="Player Control" Kind="InputPin">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="TypeFlag" Name="PlayerControl" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -7672,7 +7611,7 @@
 
 -->
             <Node Name="PlayerControl (Internal)" Bounds="765,748" Id="Fzf8dpxXYSVMYz1RG5CXtY">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="RecordDefinition" Name="Record" />
               </p:NodeReference>
               <Patch Id="LGV2YypB3yJN2k91FlipT6">
@@ -7697,7 +7636,7 @@
                   <Pad Id="GoYcM5KHizcMSEqyJHDRUr" SlotId="Um1hzyVbD88Qagwz4v4ic9" Bounds="1293,212" />
                   <Pad Id="F2WniDwvy7KMELoMQQ62ss" SlotId="FJP1eQsXbw6MzAOwL9GqAY" Bounds="1506,212" />
                   <Node Bounds="372,116,45,19" Id="DxNKobyHF8mL8VjBpFy0eX">
-                    <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Clamp" />
                     </p:NodeReference>
@@ -7707,7 +7646,7 @@
                     <Pin Id="Q8tF1CdXOe6PnyHWi1Xs9m" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="91,42,35,19" Id="KtYK71EcfeHM4DmqGuBdqk">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Max" />
                     </p:NodeReference>
@@ -7725,7 +7664,7 @@
                   <ControlPoint Id="AOEmXFWJK5XQWfZLJki4yS" Bounds="1291,274" />
                   <ControlPoint Id="CPik5ZAlW9zOfzK91SVzrr" Bounds="1505,270" />
                   <Node Bounds="91,167,44,19" Id="KCqoIXRmKRJNqHxWJXlM1n">
-                    <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Range (Join)" />
                     </p:NodeReference>
@@ -7734,7 +7673,7 @@
                     <Pin Id="E9uMNlsbvc6OYrZMt1uQAL" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="91,99,77,19" Id="TUPx4DiXY3MLbSYzzGwzIY">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromSeconds" />
                       <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -7743,7 +7682,7 @@
                     <Pin Id="Rx8AR2pYlSIPo8KVvuZnpN" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="130,126,77,19" Id="JH7cpo8yTGfOfC8dDk4dgt">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromSeconds" />
                       <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -7752,7 +7691,7 @@
                     <Pin Id="IkwiqyxO6OVOuVHISFZUcq" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="372,157,77,19" Id="CHq7wc8un7SLPCp5sOuhZK">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromSeconds" />
                       <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -7762,7 +7701,7 @@
                   </Node>
                   <Pad Id="OttPqDNY8K0M6jHaDmX9uT" SlotId="Ia8XYFcb0sFLLho2WcC1QB" Bounds="524,105" />
                   <Node Bounds="522,131,51,26" Id="MtHOqsUiyNtNTgmcTUv0ti">
-                    <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Inc" />
                       <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7775,7 +7714,7 @@
                   <Pad Id="GDvBB7RPKEyNJdDsqPtoCE" SlotId="Ia8XYFcb0sFLLho2WcC1QB" Bounds="523,452" />
                   <Pad Id="OptmoLjNkWBMS5pSZwypiI" SlotId="Ia8XYFcb0sFLLho2WcC1QB" Bounds="525,345" />
                   <Node Bounds="523,371,51,26" Id="GaAnFKh99CuQV1OCrfeDIL">
-                    <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Inc" />
                       <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7785,7 +7724,7 @@
                     <Pin Id="FVqqzuvVlzRN1YHAKj84c3" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="706,148,30,19" Id="J9Yo72DVCPbLhtve8lqkEE">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="OR" />
                     </p:NodeReference>
@@ -7871,52 +7810,52 @@
                 <Patch Id="U3EnCH1wdHtLwlzKU6dXPT" Name="Create" />
                 <Patch Id="MUE5VSN7Gf0NDDEOFAPGpM" Name="Update">
                   <Pin Id="QNpWg2mstRvQaPtoyIJuHh" MergeId="11912" Name="In Time" Kind="InputPin" Bounds="742,-12">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float64" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="VOnlFgcuk4ePOA5GYWqopz" MergeId="11914" Name="Out Time" Kind="InputPin" Bounds="817,-9" DefaultValue="99999">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float64" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="EsAT8LJUbDTMPnEvyArHvB" MergeId="11896" Name="Seek Position" Kind="InputPin" Bounds="847,231">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float64" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="GDJpUqWmUvtPx8rAa9IIWh" MergeId="11905" Name="Do Seek" Kind="InputPin" DefaultValue="False">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="RqXttVDuuoFMn7MzeL9nXE" MergeId="11936" Name="Play" Kind="InputPin" Bounds="534,12" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="NbMXRXZm2l7PrTJVE3YgxX" MergeId="11886" Name="Loop" Kind="InputPin" Bounds="699,230" DefaultValue="False">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="HebLFgNknybPG7W0MRkf33" MergeId="11925" Name="Speed" Kind="InputPin" DefaultValue="1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="DAjQ4nK88rRMkBoHGQrTD7" MergeId="11941" Name="Sync To External Time" Kind="InputPin">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="E678HPxrTWKMhVxbLGKm5g" MergeId="11951" Name="External Time" Kind="InputPin">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float64" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="I1TxbQjgVfFNXLMAnQoewS" MergeId="11958" Name="Sync To Time Timestamp Threshold" Kind="InputPin" DefaultValue="30">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -7948,7 +7887,7 @@
               </Patch>
             </Node>
             <Node Bounds="789,253,377,19" Id="BsLYF43B1kPLgEeiJZdQq0">
-              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice" LastSymbolSource="VL.Devices.AzureKinect.vl">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="PlayerControl" />
               </p:NodeReference>
@@ -7965,7 +7904,7 @@
               <Pin Id="KACRegGtG6xMuwoATDMlZa" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="631,325,51,26" Id="Nl2OTgPEpppNGRUFTYQNgn">
-              <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="Reference" />
                 <Choice Kind="OperationCallFlag" Name="SetData" />
@@ -7986,7 +7925,7 @@
             <ControlPoint Id="OVB3X7Oq1MjO4G7ysQyydQ" Bounds="1123,186" />
             <ControlPoint Id="HQkRuImqoOsMXntfFzzaRk" Bounds="1163,216" />
             <Node Bounds="522,995,65,19" Id="JCVq0TL6H0QN4tBZ4b8hzM">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -7996,7 +7935,7 @@
               <Pin Id="QFcBVKbNBCFNbqDPu2ifGt" Name="On Data" Kind="OutputPin" />
             </Node>
             <Node Bounds="522,801,123,175" Id="HmUm1YQt4rgMbrAwkhRvHs">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ProcessAppFlag" Name="ForEach" />
                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -8013,7 +7952,7 @@
                 <ControlPoint Id="Ee2WxiRpdIaP2NQZHwzvNg" Bounds="526,809" />
                 <ControlPoint Id="PjZAbrYYExyONSTWSxA8m3" Bounds="549,969" />
                 <Node Bounds="547,837,86,26" Id="VSj3n9fZACKNEfhpTA55TP">
-                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                  <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                     <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -8022,7 +7961,7 @@
                   <Pin Id="Lcb2IGCEEYvQS88ywDNLBo" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="547,880,77,26" Id="NidRfd8eqmCQN0ihWVviqa">
-                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                   </p:NodeReference>
@@ -8030,7 +7969,7 @@
                   <Pin Id="ONAi7XnCuJgO4pvls7ZmAr" Name="Total Seconds" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="547,926,62,19" Id="S7yMqV9bX2FN80DMlDrAz4">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                   </p:NodeReference>
@@ -8046,20 +7985,20 @@
 
 -->
             <Node Name="ImuPlayer (Internal)" Bounds="765,677" Id="UdnPft0liY8M8e9JpvX6zI">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ClassDefinition" Name="Class" />
               </p:NodeReference>
               <Patch Id="UWX0AceKTcmLA376zJZuLY">
                 <Canvas Id="KbTSvotxBRbMxyI2YRG1YA" CanvasType="Group">
                   <Node Bounds="564,-41,73,19" Id="T4Jj7HSwggBNPn1luZJUso">
-                    <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="CurrentTime" />
                     </p:NodeReference>
                     <Pin Id="RVsjG3Twyn7OduCV5AHxOR" Name="Current Time" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,-4,54,26" Id="NodWYV4DVp5MLawvuWlXKD">
-                    <p:NodeReference LastCategoryFullName="Animation.Time" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation.Time" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Time" />
                       <Choice Kind="OperationCallFlag" Name="Seconds" />
@@ -8068,7 +8007,7 @@
                     <Pin Id="RDjU3gciKLKNXYF7Qt0RUo" Name="Seconds" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,40,91,19" Id="JIHs39x7u6nNieJvsIYvwI">
-                    <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="FrameDifference" />
                     </p:NodeReference>
@@ -8076,7 +8015,7 @@
                     <Pin Id="TxY3Y5MW1Y7LW55MxJkHT3" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="564,138,25,19" Id="LNh80qeYn42Pswy0oMOqHq">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
@@ -8087,7 +8026,7 @@
                   </Node>
                   <Pad Id="U2fyuW5RpT8O6EpzQpbiun" SlotId="Q1BuK8kIKRCMQi2nU9ebMQ" Bounds="808,116" />
                   <Node Bounds="806,141,25,19" Id="SgeGrVHeR7TQZiIQqHZ7x9">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -8105,12 +8044,12 @@
 
 -->
                   <Node Name="FetchNextAndLoop (Internal)" Bounds="779,696,346,729" Id="KYZV5LFD69CQR3dtxn2bXd">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="Es7FLsTsjl3PbLmmzMbdfw">
                       <Node Bounds="796,742,89,26" Id="ShT2nm2lAhXL43RHNiwDnQ">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetNextCapture" />
                         </p:NodeReference>
@@ -8122,7 +8061,7 @@
                       <Link Id="Nu4qKBb9IlOMRqcQjFmtyx" Ids="D2TzTqIGgGALaZCR8Z1Qb8,Dd8gaO9GdBwPGPnkDoWeEn" />
                       <Link Id="Ur6bAdP8mgEN9ovHQLfZow" Ids="EHcezNNDmcTNSDPaLGXLPA,D2TzTqIGgGALaZCR8Z1Qb8" IsHidden="true" />
                       <Node Bounds="852,852,65,19" Id="HAhvPTItRMlPC9ZX6TC7PC">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -8131,7 +8070,7 @@
                         <Pin Id="B8jEzI1d1mZMe4SnWPxdYB" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="802,1208,127,172" Id="DXr2PHU2mFHL8BRY26uldG">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -8141,7 +8080,7 @@
                           <Patch Id="FmMkMKoM83eQW5062HByN6" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="CVoPJDurGiSOmbqgmIRbMg" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="814,1235,47,26" Id="Ro9OOLFrT9WOK3qPtzMYSs">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                               <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -8152,7 +8091,7 @@
                             <Pin Id="RBMAh4S2WZ4OvJZpWYEhHw" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="814,1275,89,26" Id="Vj2oUwyEKIsOCud9cI2P5H">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetNextCapture" />
                             </p:NodeReference>
@@ -8161,7 +8100,7 @@
                             <Pin Id="Sk97mPejis0QcHwvl5WyV7" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="814,1315,103,26" Id="PXfxUt3PFJvLy2JXDcosTT">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetNextImuSample" />
                             </p:NodeReference>
@@ -8177,7 +8116,7 @@
                       </Node>
                       <Link Id="TpKIYcugv2SOdYoFcLZtO5" Ids="FxqNBFe2qeRMFhDrpS5Hki,MkYmoACsV2cN0mmo7xPPdf" />
                       <Node Bounds="798,1145,37,19" Id="TIxWmr5cJNxLadPAmPMOqt">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -8196,7 +8135,7 @@
                       <ControlPoint Id="LbvfwpUVBNrNvYRYEC8tIp" Bounds="864,1408" />
                       <Link Id="AllyvnZmOkeN2BpeyMQh7w" Ids="LbvfwpUVBNrNvYRYEC8tIp,LEnAj0wiRT8NcqqS41S7Yc" IsHidden="true" />
                       <Node Bounds="1019,948,38,26" Id="PEUjL3kshvaMcrggFYSFLi">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -8211,7 +8150,7 @@
                       <Link Id="FyUsmi6T4VNOLhU6hdwrTu" Ids="S82cKYAxb5ROYktOFFq1xH,JeA94zXFvhlMn4Rqdpf1xp" />
                       <Link Id="FaOgW2ueJaoO6k3DOO5qco" Ids="Lde7NYZNDqrLR25P32i0GX,U4DLDG1tO0NNdP37Gh1ub1" />
                       <Node Bounds="1022,1170,25,19" Id="MGYmcBqKuFvOR2OcJhAEmt">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -8223,17 +8162,19 @@
                       <Link Id="SVz7GHxn1SYQc9BupC4KUb" Ids="C38vPHdUXaVNoWldm5yP9Q,J9UUA0DRwFxLgpqA5c2cuu" />
                       <Link Id="D8p4IHyGyKHNnrv78EhSbQ" Ids="KGWSRJkxUVGPn2O2Sdh6Ni,C38vPHdUXaVNoWldm5yP9Q" IsHidden="true" />
                       <Node Bounds="852,927,111,114" Id="CjCoXhbjnajN5hGo7cV1t7">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="QpgBwHhHMKvNAW91WitJ3y" Name="Condition" Kind="InputPin" />
+                        <ControlPoint Id="EgsztIORDAcNSHIwBiFklk" Bounds="867,1035" Alignment="Bottom" />
+                        <ControlPoint Id="JEn1DBMIEv4LYcKnsmBDIR" Bounds="866,933" Alignment="Top" />
                         <Patch Id="D5MLrYce1vIQKZaAQOwKlO" ManuallySortedPins="true">
                           <Patch Id="MUQIoTS50WrME9qsTO6Lp0" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="LJ6ZMPbDO9LNZzrzSsA1Ue" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="865,956,86,26" Id="Ip3v1dLGVFcPkSNEVfjlxf">
-                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                               <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -8242,7 +8183,7 @@
                             <Pin Id="Gsw3KiGGHuULmYoSmt3tQL" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="865,996,25,19" Id="J5BoOyCAUKzLAzzvKTYcVF">
-                            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="&gt;" />
                             </p:NodeReference>
@@ -8251,8 +8192,6 @@
                             <Pin Id="IkGBl7cus5TO5PweRwju9w" Name="Result" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="EgsztIORDAcNSHIwBiFklk" Bounds="867,1035" Alignment="Bottom" />
-                        <ControlPoint Id="JEn1DBMIEv4LYcKnsmBDIR" Bounds="866,933" Alignment="Top" />
                       </Node>
                       <Link Id="SIZpILwSUF2Ppqpstt6fSC" Ids="M4aR9D97R0WNhxQLDOLVui,QpgBwHhHMKvNAW91WitJ3y" />
                       <Link Id="LVFdE83irVqLQ6PmWHYWEk" Ids="JEn1DBMIEv4LYcKnsmBDIR,EgsztIORDAcNSHIwBiFklk" IsFeedback="true" />
@@ -8261,7 +8200,7 @@
                       <Link Id="UK1Y2MuWne9QOqOuH1N6Ui" Ids="UYIOn9kFSTzMUDCGVcVGvL,CsrmrPqBhV9MdHFQGcwBTs" />
                       <Link Id="UGmj9lqw9ANLPz9PJ9jpsx" Ids="IkGBl7cus5TO5PweRwju9w,EgsztIORDAcNSHIwBiFklk" />
                       <Pad Id="Jn7iBf0kX7gPHPitnrRaYz" Comment="" Bounds="866,889,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -8275,7 +8214,7 @@
                       <ControlPoint Id="NMfWBadbIZaMrFwJ1eHIGI" Bounds="926,1406" />
                       <Link Id="PYzhcIW0knEOLsXfB1Z78w" Ids="NMfWBadbIZaMrFwJ1eHIGI,AZo42o0KtZcLLjPEewSwo8" IsHidden="true" />
                       <Node Bounds="812,797,103,26" Id="K7NVQglmtIEML6Z054ZZdy">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetNextImuSample" />
                         </p:NodeReference>
@@ -8288,9 +8227,8 @@
                       <Link Id="RNLz8NbrUDHOt6owaRp0e3" Ids="Qxusp1OjEPrOorJ30cqUF4,AxUVLZj3446ODAFPK12vgl" />
                       <Pin Id="EHcezNNDmcTNSDPaLGXLPA" Name="Input" Kind="InputPin" Bounds="1442,875" />
                       <Pin Id="AmN6DnLlwVLNGdaS2mN1I9" Name="Loop" Kind="InputPin" Bounds="1616,904" />
-                      <Pin Id="LEnAj0wiRT8NcqqS41S7Yc" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="UitDZWfCaQcMnJsBtPZ95s" Name="Time Range" Kind="InputPin" Bounds="1598,1017">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Range" />
                           <p:TypeArguments>
                             <TypeReference>
@@ -8300,6 +8238,7 @@
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="KGWSRJkxUVGPn2O2Sdh6Ni" Name="Initial Offset" Kind="InputPin" Bounds="1668,700" />
+                      <Pin Id="LEnAj0wiRT8NcqqS41S7Yc" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="AZo42o0KtZcLLjPEewSwo8" Name="Imu Sample" Kind="OutputPin" Bounds="921,1405" />
                     </Patch>
                   </Node>
@@ -8309,12 +8248,12 @@
 
 -->
                   <Node Name="FetchPreviousAndLoop (Internal)" Bounds="1265,701,300,733" Id="M57l7CcR3dmOvhwQzTHhpt">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="JllGE4ov0ekM5N5kxLwg2m">
                       <Node Bounds="1293,746,106,26" Id="MQnOHA4D72kL85LICe2Q19">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPreviousCapture" />
                         </p:NodeReference>
@@ -8326,7 +8265,7 @@
                       <Link Id="VWSzEeU9u3pOWoucg73ob4" Ids="KQ2I0iojfjxNnt7IZNVNzw,DgyrZWeOjiXOymop9ryW7T" />
                       <Link Id="Mf5mt6FqbkhNha0uTraqEp" Ids="UoM3UMa80kHNfbTyUvTZ6G,KQ2I0iojfjxNnt7IZNVNzw" IsHidden="true" />
                       <Node Bounds="1288,1208,157,176" Id="IrcSgRKGuA4MY5PNDXJJAT">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -8338,7 +8277,7 @@
                           <Patch Id="VqCjPYCXws4NUHHXfh1cMY" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="Ryx3eg08muqMxm3h7CReoK" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="1301,1234,47,26" Id="CadI1xgBIAWPhNFdWu9CAq">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                               <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -8349,7 +8288,7 @@
                             <Pin Id="Mlbd99jCKcZLqEQNNipLTX" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="1301,1276,106,26" Id="FQDVHSQd2y4NkvB9yzX5eh">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetPreviousCapture" />
                             </p:NodeReference>
@@ -8358,7 +8297,7 @@
                             <Pin Id="CT6tsx24if5OM5fw8BcG8P" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1300,1323,120,26" Id="FsgXn0cIq7SPQw42HmqgeG">
-                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                            <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetPreviousImuSample" />
                             </p:NodeReference>
@@ -8372,7 +8311,7 @@
                       </Node>
                       <Link Id="IHwm295HrFzNXUfG6x4LPb" Ids="JcMyF7lJdo2O5mZ68Yl5a5,CMCbgoRcOBfPYv7J9ja5ux" />
                       <Node Bounds="1291,1157,37,19" Id="Rdm5X6dRpaQLyhtX8an248">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -8391,7 +8330,7 @@
                       <ControlPoint Id="HXjYi8sRZPFO056aeGdMVF" Bounds="1405,1417" />
                       <Link Id="Vghw2YhhNa7L1hfkPfNh9p" Ids="HXjYi8sRZPFO056aeGdMVF,D7of7Z2jdm2MS2YwK0SuKt" IsHidden="true" />
                       <Node Bounds="1459,929,38,26" Id="A6JZBFFCCDfO09gtGUgpP8">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -8405,7 +8344,7 @@
                       <Link Id="EgGOPNqYiwYQKUtH5TRaWd" Ids="LSd7hClvuFJM23wLRWLrud,DOvMKetXPE5QR88UAUN6TI" IsHidden="true" />
                       <Link Id="U5IjP1cdKCkPY3sRHXzI7g" Ids="DxfZDNjvdrLP7ItJRPTW5n,NwLQjMAQsopNknuNlUlj9r" />
                       <Node Bounds="1464,1142,25,19" Id="J9LChCklMQeOMYwwBvbDcQ">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -8418,7 +8357,7 @@
                       <Link Id="O903WoaOyRqOJDbBKYITZk" Ids="Alvl47fCYUOPot12nwXwto,B0dXaHFCly3Ms9Mk9VkaAC" IsHidden="true" />
                       <Link Id="J1sFFKrqHaBL8zbyJX7mov" Ids="GAC7ndsdkeBMQD6eRyiqiA,AJNurm3Pew4MuyDN9Od95j" />
                       <Node Bounds="1327,843,65,19" Id="DtPy0Rsp7QdLMr2JuBynu4">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -8427,17 +8366,19 @@
                         <Pin Id="RPnMipH6f40PUZQvhXyKwe" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1327,918,111,114" Id="P0swLPKilVpPTZv1bySqOe">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="RP3Bw8SqGmzMiZ0dqlEPQS" Name="Condition" Kind="InputPin" />
+                        <ControlPoint Id="TFxu2kdxRXnLJV8lw2AyCV" Bounds="1342,1026" Alignment="Bottom" />
+                        <ControlPoint Id="Nj0f6RbBcNiL2LfxeQJVg7" Bounds="1341,924" Alignment="Top" />
                         <Patch Id="SrQ2HeP05hdLcymLVw6iQ3" ManuallySortedPins="true">
                           <Patch Id="HdGJxZVD1v5NvBb7enmuar" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="NBWmwP5Pz20MTIJ23ajjEw" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="1340,947,86,26" Id="V8fbm9NjwagNdfHYa0fi9l">
-                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                            <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                               <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -8446,7 +8387,7 @@
                             <Pin Id="UX00tpFWQmYOHvAZAUA25W" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1340,987,25,19" Id="RBBfxu3VCi1PYRiIG2N6tB">
-                            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="&lt;" />
                               <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -8456,11 +8397,9 @@
                             <Pin Id="HEW6vgE0ZvdQBUpLBuaWNF" Name="Result" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="TFxu2kdxRXnLJV8lw2AyCV" Bounds="1342,1026" Alignment="Bottom" />
-                        <ControlPoint Id="Nj0f6RbBcNiL2LfxeQJVg7" Bounds="1341,924" Alignment="Top" />
                       </Node>
                       <Pad Id="Jbf4Ncd15vbOv0DulVk1Je" Comment="" Bounds="1341,880,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -8481,7 +8420,7 @@
                       <ControlPoint Id="AxH2Xwy9qjnPqZMUei0F5d" Bounds="1459,1415" />
                       <Link Id="TAApT25IMJfP3OLHazkBfc" Ids="AxH2Xwy9qjnPqZMUei0F5d,MJziMYqZONLLv7WBaZ3qeZ" IsHidden="true" />
                       <Node Bounds="1295,789" Id="EJO6g6Nk9UQLBP8tcOoKwa">
-                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                        <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPreviousImuSample" />
                         </p:NodeReference>
@@ -8493,9 +8432,8 @@
                       <Link Id="NUVkbLjbtUDQSSI3gbmyJi" Ids="EApx34NitnaO8YozjzvLpU,ArtZ6j5XB9COKUC9dKmQZR" />
                       <Pin Id="UoM3UMa80kHNfbTyUvTZ6G" Name="Input" Kind="InputPin" Bounds="1442,875" />
                       <Pin Id="TwOchHhasUkMUefELCjNtB" Name="Loop" Kind="InputPin" Bounds="1616,904" />
-                      <Pin Id="D7of7Z2jdm2MS2YwK0SuKt" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="LSd7hClvuFJM23wLRWLrud" Name="Time Range" Kind="InputPin" Bounds="1598,1017">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Range" />
                           <p:TypeArguments>
                             <TypeReference>
@@ -8505,12 +8443,13 @@
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="Alvl47fCYUOPot12nwXwto" Name="Initial Offset" Kind="InputPin" Bounds="1668,700" />
+                      <Pin Id="D7of7Z2jdm2MS2YwK0SuKt" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
                       <Pin Id="MJziMYqZONLLv7WBaZ3qeZ" Name="Imu Sample" Kind="OutputPin" Bounds="1459,1415" />
                     </Patch>
                   </Node>
                   <Pad Id="DP9MUHfmx4NLUlNKd6pnGI" SlotId="NEFVj3wLLMoLOzqyIXBVll" Bounds="896,416" />
                   <Node Bounds="874,435,25,19" Id="ADgl6rf3Hu0QVsVTMYl7hS">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="-" />
                     </p:NodeReference>
@@ -8519,7 +8458,7 @@
                     <Pin Id="Rm72bTBjSjvL5FiGjeV8OW" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="874,467,34,19" Id="SDZmw5apSX2O5Tyda2rTx0">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Abs" />
                     </p:NodeReference>
@@ -8527,14 +8466,14 @@
                     <Pin Id="TQVwiYeLsz8NJ5ATKVlm3i" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="326,705,40,19" Id="N0YAtq9NAQCPmRyxvihsp7">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NULL" />
                     </p:NodeReference>
                     <Pin Id="BWqq0eU0alKPzI2loxjD1Z" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="359,166,131,26" Id="ECFZ054szMYLJd3dWFyqEZ">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                       <Choice Kind="OperationCallFlag" Name="GetStartTimestampOffset" />
@@ -8543,7 +8482,7 @@
                     <Pin Id="JyZmK2nZ9DwN31PS7Ftu0r" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="238,207,86,26" Id="EECzCLuFh7jN7Kr9v8IsZD">
-                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                    <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                       <Choice Kind="OperationCallFlag" Name="GetFrameRate" />
@@ -8552,12 +8491,12 @@
                     <Pin Id="VBwApfX8xW9NzFB6cedJ2A" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="218,277,25,19" Id="J9URomn0OGGMkS5a2r8Gh0">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="/" />
                     </p:NodeReference>
                     <Pin Id="QrQCvTS8fVVQU5Bu2sVN9m" Name="Input" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -8565,7 +8504,7 @@
                     <Pin Id="MSYqSOVfJAKPeAyjp1zuTw" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="238,246,62,19" Id="TdlDvDRixn0MqpubQSUVPK">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                     </p:NodeReference>
@@ -8573,7 +8512,7 @@
                     <Pin Id="RaDvRabevmcM3kxNlkHuPf" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="289,734,309,259" Id="ARLvoJGHplpOfkWt9ZpmxJ">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -8583,11 +8522,13 @@
                     <ControlPoint Id="SquIebh6iSHM6k3EFXJ2Mh" Bounds="326,741" Alignment="Top" />
                     <ControlPoint Id="El92gB08Y8gM6FqFdIMFKV" Bounds="545,741" Alignment="Top" />
                     <ControlPoint Id="GrLr4PlRsRXO4kfAhIFidG" Bounds="581,987" Alignment="Bottom" />
+                    <ControlPoint Id="St2mfVUPE28NT3HCv4rBvD" Bounds="440,987" Alignment="Bottom" />
+                    <ControlPoint Id="EyYfPgUVdc4PdHYbuzwbkO" Bounds="434,741" Alignment="Top" />
                     <Patch Id="Lgl5AMKtYPVNnamS7OnUBL" ManuallySortedPins="true">
                       <Patch Id="QPRMYxycHdKOuuZLrpDLdP" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="IEjdN3Ab7BUNA57nSgBDsX" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="313,774,138,89" Id="JGXWCyqZeHBOcfSxxyXD2s">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
@@ -8595,11 +8536,13 @@
                         <Pin Id="Ffljh1nAmp1LLFRugKYuYd" Name="Condition" Kind="InputPin" />
                         <ControlPoint Id="IdWv768eDzYMfVW9f5M6LL" Bounds="327,858" Alignment="Bottom" />
                         <ControlPoint Id="L0HFxOvXH9xQV2M215d6Ed" Bounds="327,781" Alignment="Top" />
+                        <ControlPoint Id="VmywwV7NF76Owvb726pvLI" Bounds="425,858" Alignment="Bottom" />
+                        <ControlPoint Id="Prqwg3RxmxrMgCXaHS1vpk" Bounds="434,781" Alignment="Top" />
                         <Patch Id="UraR4vXc9AhQGZ2QcG26de" ManuallySortedPins="true">
                           <Patch Id="VFcn5Ndhsj0OviVltPiAdK" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="F3pdbAOK0CyMc3QfO0vUNt" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="325,810,103,19" Id="V1Q4dIl7gtwM5U3BkfM85q">
-                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.ImuPlayer" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.ImuPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FetchNextAndLoop" />
                               <CategoryReference Kind="ClassType" Name="ImuPlayer" NeedsToBeDirectParent="true" />
@@ -8612,11 +8555,9 @@
                             <Pin Id="ONPIlvToQwXOJSI8FWjvrP" Name="Imu Sample" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="VmywwV7NF76Owvb726pvLI" Bounds="425,858" Alignment="Bottom" />
-                        <ControlPoint Id="Prqwg3RxmxrMgCXaHS1vpk" Bounds="434,781" Alignment="Top" />
                       </Node>
                       <Node Bounds="312,880,143,87" Id="ArSrYDZnH4kLTpXxnt0uTq">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
@@ -8624,11 +8565,13 @@
                         <Pin Id="CusoxhBtHu7MVhUhzjSIBL" Name="Condition" Kind="InputPin" />
                         <ControlPoint Id="KWajxeJWhH3NMN04TvPbdW" Bounds="327,894" Alignment="Top" />
                         <ControlPoint Id="VJ8oRbCNeqHN3oWsfACdaP" Bounds="327,961" Alignment="Bottom" />
+                        <ControlPoint Id="Rqs5tqxUSU0QLTjSGeW1Jr" Bounds="429,886" Alignment="Top" />
+                        <ControlPoint Id="Rd6rqpdjedtNabs6Nzxpqo" Bounds="438,961" Alignment="Bottom" />
                         <Patch Id="LZqUOrfe3Z5PVW2BEjPMvB" ManuallySortedPins="true">
                           <Patch Id="EpTYuhJrutZQNBGfGf8cnL" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="RtxFRs927YuMwk6zQsU5PQ" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="324,913,119,19" Id="BaRzwFnRSNTNgVDWU70ayD">
-                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.ImuPlayer" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                            <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.ImuPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FetchPreviousAndLoop" />
                               <CategoryReference Kind="ClassType" Name="ImuPlayer" NeedsToBeDirectParent="true" />
@@ -8641,15 +8584,11 @@
                             <Pin Id="Al89eYTnvOuN21ubjQ64v6" Name="Imu Sample" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="Rqs5tqxUSU0QLTjSGeW1Jr" Bounds="429,886" Alignment="Top" />
-                        <ControlPoint Id="Rd6rqpdjedtNabs6Nzxpqo" Bounds="438,961" Alignment="Bottom" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="St2mfVUPE28NT3HCv4rBvD" Bounds="440,987" Alignment="Bottom" />
-                    <ControlPoint Id="EyYfPgUVdc4PdHYbuzwbkO" Bounds="434,741" Alignment="Top" />
                   </Node>
                   <Node Bounds="874,533,25,19" Id="A32mV0NUEunMbmo5qWiHWK">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -8659,20 +8598,20 @@
                     <Pin Id="NnpnCicR2jFLGxr5RcyBqF" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="894,502,25,19" Id="ENqfbWDvM5LL89IbFhJ0de">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
                     <Pin Id="VLCZUbqZkTmL7m0lIYTM2V" Name="Input" Kind="InputPin" />
                     <Pin Id="VRC31UVF41lL0pxdDBcm6T" Name="Scalar" Kind="InputPin" DefaultValue="0.5">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="Ikm0Na2Azx3Muj4Ih5y3ru" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="249,656,65,26" Id="TN5UwVPiv7EOAqbLTuLcBv">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                       <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -8684,7 +8623,7 @@
                     <Pin Id="RFq8FFDVmnUQEgKrlsIc2u" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="338,557,77,19" Id="BA7eY3pNeztMgVNzrNEQaa">
-                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromSeconds" />
                       <CategoryReference Kind="RecordType" Name="TimeSpan" NeedsToBeDirectParent="true" />
@@ -8693,7 +8632,7 @@
                     <Pin Id="VflsryzSIlSLjFkbgRaufg" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="382,1091,65,19" Id="HKTkxvp0wRWLdwtJqx41it">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -8702,17 +8641,19 @@
                     <Pin Id="QrVNA4fwG2lOYYykLmS9Ca" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="387,1172,110,166" Id="MU1qr6Z1zU8LHetnb3J246">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
                     <Pin Id="K3SxcO6PhcZLlZh4wHQZQm" Name="Condition" Kind="InputPin" />
+                    <ControlPoint Id="Mj3jY3QmQvvNOueFGBSzF9" Bounds="408,1332" Alignment="Bottom" />
+                    <ControlPoint Id="QUjpXXla5CEL4OhRfkINOH" Bounds="408,1178" Alignment="Top" />
                     <Patch Id="H4t6E0aJaIYMyvRovjK1VM" ManuallySortedPins="true">
                       <Patch Id="VmPKgcpdQL1ONgNWrdDjjp" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="Fe45mmvjbwrMNWf1uQnJN1" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="399,1211,86,26" Id="ULtJKdMwT7MORaD4iazaat">
-                        <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastSymbolSource="VL.Devices.AzureKinect.dll">
+                        <p:NodeReference LastCategoryFullName="VL.Devices.AzureKinect.PlaybackExtensions" LastDependency="VL.Devices.AzureKinect.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="PlaybackExtensions" />
                           <Choice Kind="OperationCallFlag" Name="GetTimestamp" />
@@ -8721,7 +8662,7 @@
                         <Pin Id="KxOMpChaoWPLwcwytplvkJ" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="399,1254,77,26" Id="Lh6W02lPGZELSouDV3FJAa">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -8729,13 +8670,11 @@
                         <Pin Id="CRXSPswCXTdOlx83sJ7tY9" Name="Total Seconds" Kind="OutputPin" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="Mj3jY3QmQvvNOueFGBSzF9" Bounds="408,1332" Alignment="Bottom" />
-                    <ControlPoint Id="QUjpXXla5CEL4OhRfkINOH" Bounds="408,1178" Alignment="Top" />
                   </Node>
                   <Pad Id="GJ26B96CFpWPzvgSb2joP4" SlotId="NEFVj3wLLMoLOzqyIXBVll" Bounds="413,1141" />
                   <Pad Id="UraYdkebeAAMpkhgJVIXlf" SlotId="RhQeBGnkASXOu59AAH14CH" Bounds="546,231" />
                   <Node Bounds="544,258,25,19" Id="FAbglknx9TSLUEQSiEed95">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -8745,7 +8684,7 @@
                   </Node>
                   <Pad Id="V0rNVSf4gMrLLO8JXBP651" SlotId="RhQeBGnkASXOu59AAH14CH" Bounds="582,1034" />
                   <Node Bounds="192,339,31,19" Id="LrAy6Cn1bHbLEeMewuItbr">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;=" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -8755,7 +8694,7 @@
                     <Pin Id="Q2Upjg1sbr6OMx31q2uHil" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="148,741,31,19" Id="OlmHFovwRspMy9cPQgHKj4">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;=" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -8765,7 +8704,7 @@
                     <Pin Id="MqgLLsvioxiM37nN9D3yS5" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="146,850,25,19" Id="Ehq8LwRF5f5Oat1p3FyFTL">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&lt;" />
                     </p:NodeReference>
@@ -8774,7 +8713,7 @@
                     <Pin Id="OMtnQFuoNKtNPZivDnTpAY" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="584,105,34,19" Id="Li1WoRswpKaLXwWJSLMtX4">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Abs" />
                     </p:NodeReference>
@@ -8782,7 +8721,7 @@
                     <Pin Id="H1sXgHBFXSMPpYVHHpQfnz" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="826,102,25,19" Id="E6TAGZbyu6KOISFYzV88rq">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                     </p:NodeReference>
@@ -8792,7 +8731,7 @@
                     <Pin Id="TPxzu7jLyY2QQQesGnksOU" Name="Scalar 2" Kind="InputPin" />
                   </Node>
                   <Node Bounds="277,603,25,19" Id="MGwSZphGJp2NLGfI73xxEj">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -8806,12 +8745,12 @@
 
 -->
                   <Node Name="TimeLoop" Bounds="1285,295,263,189" Id="FfTKEd51ZGjLGygyCzeaG8">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="TP2JEEot1WINXRsvbaQoO6">
                       <Node Bounds="1298,423,105,19" Id="IRvobEXQ2ZtNVk8wW4OcTe">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="MapWrap" />
                           <CategoryReference Kind="Category" Name="Ranges" NeedsToBeDirectParent="true" />
@@ -8825,7 +8764,7 @@
                       </Node>
                       <ControlPoint Id="Iqq8OC42ifyPmYg2XAWgVA" Bounds="1359,313" />
                       <Node Bounds="1357,330,38,26" Id="QRYbx6A5EWlPAsS4OGG3iU">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Range" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
@@ -8835,7 +8774,7 @@
                         <Pin Id="B0Ee4q49l3MOZeG1eoQWmI" Name="To" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1357,369,77,26" Id="UxJYlzbsJtMPxmmWkOWjM2">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -8843,7 +8782,7 @@
                         <Pin Id="Vn4vhoLLunJLo8SvG3ltEL" Name="Total Seconds" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1459,369,77,26" Id="HvRGwb4HVMkQUOX0xN0hKt">
-                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TotalSeconds" />
                         </p:NodeReference>
@@ -8870,7 +8809,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="806,181,126,19" Id="O6BJb0YTXFULfBBe3Bupvq">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.ImuPlayer" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.ImuPlayer" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="TimeLoop" />
                       <CategoryReference Kind="ClassType" Name="ImuPlayer" NeedsToBeDirectParent="true" />
@@ -8881,7 +8820,7 @@
                     <Pin Id="JIaAzhF2hWvO4R7PSGYW20" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="794,302,31,41" Id="A8ygSOIdgvPMAUpj4yAB1H">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -8895,7 +8834,7 @@
                     <ControlPoint Id="BVAmjIebb6ENFRCAayI0AU" Bounds="808,309" Alignment="Top" />
                   </Node>
                   <Node Bounds="166,554,65,26" Id="TAlmmqbck8nQBinSwBb6Kh">
-                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.Record.dll">
+                    <p:NodeReference LastCategoryFullName="Microsoft.Azure.Kinect.Sensor.Record.Playback" LastDependency="Microsoft.Azure.Kinect.Sensor.Record.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Playback" />
                       <Choice Kind="OperationCallFlag" Name="Seek" />
@@ -8907,7 +8846,7 @@
                     <Pin Id="ELeMqvexrXWLkknwKLtMVk" Name="Apply" Kind="InputPin" />
                   </Node>
                   <Node Bounds="842,565,37,19" Id="O1S9b27sB3oNvQnoj2Re50">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                     </p:NodeReference>
@@ -8917,7 +8856,7 @@
                   </Node>
                   <ControlPoint Id="Fp9lzgCwdMOQX9nhlS4XAJ" Bounds="918,47" />
                   <Node Bounds="916,70,82,26" Id="OxbXoJZZjz6Mcd87zzZIhM">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetTimeRange" />
                     </p:NodeReference>
@@ -8926,7 +8865,7 @@
                   </Node>
                   <ControlPoint Id="Aqx2opYVhQuMkYrD0dDTMV" Bounds="640,737" />
                   <Node Bounds="638,760,82,26" Id="L2y9MkSGzzyQN7AGF6CCiV">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetTimeRange" />
                     </p:NodeReference>
@@ -8934,7 +8873,7 @@
                     <Pin Id="LwV7GLD4JU4LlZlTdRgMXo" Name="Time Range" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="794,262,123,26" Id="FOBBEEiKmw4Oso2HyXp9Q0">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSyncToExternalTime" />
                     </p:NodeReference>
@@ -8946,7 +8885,7 @@
                   <ControlPoint Id="PPxuH4yW86bNJqjqB7I8X6" Bounds="796,241" />
                   <ControlPoint Id="SoEPvrVCCAdN2FAjwgq9zD" Bounds="749,-36" />
                   <Node Bounds="747,-9,64,26" Id="UL7JPaiBZDUQCFwwFqSDu3">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSpeed" />
                     </p:NodeReference>
@@ -8955,7 +8894,7 @@
                   </Node>
                   <ControlPoint Id="KSwsBlJUXJpLDdQrjS68ft" Bounds="1021,107" />
                   <Node Bounds="1019,122,64,26" Id="GdozFaaSfJHOPd9Kp63jxJ">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetLoop" />
                     </p:NodeReference>
@@ -8964,7 +8903,7 @@
                   </Node>
                   <ControlPoint Id="G4Bmr1FpN1RLxUx59OlHZ3" Bounds="592,663" />
                   <Node Bounds="590,678,64,26" Id="DnSNgN9PoJ8LQ17WUjevv8">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetLoop" />
                     </p:NodeReference>
@@ -8972,12 +8911,12 @@
                     <Pin Id="Uy4mgqagWXBNNoUvk96Jn9" Name="Loop" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="226,514,57,19" Id="J6tQtJsGRqvPsXNujv9qiD">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Changed" />
                     </p:NodeReference>
                     <Pin Id="IGa2BVOh6s6MqOCU2pgxic" Name="Changed On Create" Kind="InputPin" DefaultValue="False">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -8986,7 +8925,7 @@
                     <Pin Id="VnkFe3bUhS8QZGT6mTc2oA" Name="Unchanged" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="186,458,64,26" Id="R8bSD4EldUcNFGFHOCDgNL">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSeek" />
                     </p:NodeReference>
@@ -8997,7 +8936,7 @@
                   <ControlPoint Id="CbxJfTZqIMjOBqHH3ohCYo" Bounds="188,442" />
                   <ControlPoint Id="Q3S2xMYpeDbOkniiii6GgL" Bounds="110,665" />
                   <Node Bounds="108,692,64,26" Id="KALM5eosUmqLLZYOLaBjK7">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSpeed" />
                     </p:NodeReference>
@@ -9006,7 +8945,7 @@
                   </Node>
                   <ControlPoint Id="SCWHCGV9Ru6Pslbx84Xfv7" Bounds="870,-34" />
                   <Node Bounds="868,-7,64,26" Id="TQFWmtT9G1sP4cT2W5CnJi">
-                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.PlaybackDevice.PlayerControl" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                    <p:NodeReference LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer.PlayerControl" LastDependency="VL.Devices.AzureKinect.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetPlay" />
                     </p:NodeReference>
@@ -9129,16 +9068,6 @@
                 <Link Id="BTtdS6Sep8sOPk2RyJA3CR" Ids="SCWHCGV9Ru6Pslbx84Xfv7,CH9cKyVpdOkNIgy6WhNSp5" />
                 <Link Id="CnzShhc8YL4MWJgQ3QGSCQ" Ids="J0iqsqgb379NGj2mSaOr9v,TPxzu7jLyY2QQQesGnksOU" />
                 <Link Id="G1aM6tA3SYELMWpqUL1q9M" Ids="J0iqsqgb379NGj2mSaOr9v,Nz7VsO99yUEMjf1edHVdoL" />
-                <Patch Id="FmJvR4PJ8tQPCKb3pRhGRa" Name="Create" />
-                <Patch Id="SygrlbFVDFCNMQJopq19GW" Name="Update" ParticipatingElements="FSz7Xt6yLzNOmoVYcdOgo4">
-                  <Pin Id="Uc4e6uw8QuILGCEstHbksC" Name="Player Control" Kind="InputPin">
-                    <p:TypeAnnotation>
-                      <Choice Kind="TypeFlag" Name="PlayerControl" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="EPEXSkyfnIMOm8t3USLhVH" Name="Input" Kind="InputPin" Bounds="1442,875" />
-                  <Pin Id="DGjT21XnP3gMEKNjzRARXe" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
-                </Patch>
                 <Link Id="H1VrqjMMHRJLGqjDDmVwJS" Ids="Prqwg3RxmxrMgCXaHS1vpk,VmywwV7NF76Owvb726pvLI" IsFeedback="true" />
                 <Link Id="EsoDVcXEhmCNt8s4l5l8cA" Ids="ONPIlvToQwXOJSI8FWjvrP,VmywwV7NF76Owvb726pvLI" />
                 <Link Id="VM2HsDnErp7QGKgGGFEMCk" Ids="Rqs5tqxUSU0QLTjSGeW1Jr,Rd6rqpdjedtNabs6Nzxpqo" IsFeedback="true" />
@@ -9151,6 +9080,16 @@
                 <Slot Id="CCkwmT5Y4m9PklKpFiE83x" Name="Imu Sample" />
                 <Link Id="Oh6FZHI0adZMxF9TIL76Zv" Ids="St2mfVUPE28NT3HCv4rBvD,Cb2iKjUPBN1LD3zVFSaLD3" />
                 <Link Id="Mhf5sRIZ5NkOeHUU5ZKEfM" Ids="BpiJ8SjyXpjPeGcQPdqo61,EyYfPgUVdc4PdHYbuzwbkO" />
+                <Patch Id="FmJvR4PJ8tQPCKb3pRhGRa" Name="Create" />
+                <Patch Id="SygrlbFVDFCNMQJopq19GW" Name="Update" ParticipatingElements="FSz7Xt6yLzNOmoVYcdOgo4">
+                  <Pin Id="Uc4e6uw8QuILGCEstHbksC" Name="Player Control" Kind="InputPin">
+                    <p:TypeAnnotation LastCategoryFullName="Devices.AzureKinect.AzureKinectPlayer" LastDependency="VL.Devices.AzureKinect.vl">
+                      <Choice Kind="TypeFlag" Name="PlayerControl" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="EPEXSkyfnIMOm8t3USLhVH" Name="Input" Kind="InputPin" Bounds="1442,875" />
+                  <Pin Id="DGjT21XnP3gMEKNjzRARXe" Name="Result" Kind="OutputPin" Bounds="1470,1149" />
+                </Patch>
               </Patch>
             </Node>
           </Canvas>
@@ -9250,7 +9189,7 @@
           <Patch Id="RFSuTlS20k1LgsdGM39Vbs" Name="Create (Internal)" />
           <Patch Id="AWnC0deqS2AMyayt3Fm7nH" Name="GetCaptures (Internal)">
             <Pin Id="D6JrITAobMOOGqfZKGgQpv" Name="Captures" Kind="OutputPin">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -9264,18 +9203,18 @@
             <Pin Id="LQXIUg9AnHiMygvpTzdbHI" Name="Play" Kind="InputPin" Bounds="849,226" />
             <Pin Id="NPMfY1E91RcN54ilDXceDu" Name="Rate" Kind="InputPin" Bounds="931,270" Summary="Playback speed multiplier: e.g: 1.0 = normal speed, 0.5 = half speed, 2.0 = double speed" />
             <Pin Id="BxwpPqNGuUeMOTLMg6aD6j" Name="Seek Time" Kind="InputPin" Bounds="766,305">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="G2GCYYWWNSPPMjMtB5cYpn" Name="Seek" Kind="InputPin" Bounds="808,327" />
             <Pin Id="LBgsix4196PPujxMRnZf7E" Name="Loop Start Time" Kind="InputPin">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="I0vARYI16maMUXJJsiJImO" Name="Loop End Time" Kind="InputPin" DefaultValue="9999">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -9310,11 +9249,11 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="MsqCX6Ttc4CLXiQVDI6QhQ" Location="VL.Skia" Version="2021.4.12" />
+  <NugetDependency Id="MsqCX6Ttc4CLXiQVDI6QhQ" Location="VL.Skia" Version="2023.5.0" />
   <PlatformDependency Id="JvKnBkMg9y5QJxBrHlbiSn" Location="VL.Devices.AzureKinect.dll" />
   <NugetDependency Id="KZAfO3faLstMCFyjB36g9Y" Location="System.Numerics.Vectors" Version="4.5.0" />
   <NugetDependency Id="BjHHosGh8QaNOegumIQQIC" Location="VL.Skia3d" Version="1.1.2" />
-  <NugetDependency Id="VJjJ4uUjfMCMWx9Df4PSWA" Location="VL.Stride.Runtime" Version="2021.4.12" />
+  <NugetDependency Id="VJjJ4uUjfMCMWx9Df4PSWA" Location="VL.Stride.Runtime" Version="2023.5.0" />
   <PlatformDependency Id="QFgM5jDAhfxPsQ0SrkSAPc" Location="./dependencies/Microsoft.Azure.Kinect.Sensor/Microsoft.Azure.Kinect.Sensor.dll" />
   <PlatformDependency Id="GML7Urt30mJOajUQRUztY1" Location="./dependencies/Microsoft.Azure.Kinect.Sensor.Record/Microsoft.Azure.Kinect.Sensor.Record.dll" />
 </Document>

--- a/deployment/VL.Devices.AzureKinect.nuspec
+++ b/deployment/VL.Devices.AzureKinect.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>VL.Devices.AzureKinect</id>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <title>VL.Devices.AzureKinect</title>
     <authors>vvvv</authors>
     <owners>vvvv</owners>


### PR DESCRIPTION
the ColorToDepthImage currently only exists as a non-reactive version, while the others (color, depth, infrared) have reactive versions as well.
i added it in the 'experimental' category where the original node resides too.